### PR TITLE
Fix formatNumber edge case

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -605,7 +605,8 @@ class DrillDowner {
     }
 
     static formatNumber(n, decimals) {
-        if(isNaN(n)) return n;
+        if (n === '' || n === null) return '';
+        if (isNaN(n)) return n;
         return Number(n).toLocaleString('en-US', {
             minimumFractionDigits: decimals,
             maximumFractionDigits: decimals


### PR DESCRIPTION
## Summary
- handle empty string and null when formatting numbers

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_687bd6e76e64833084fa4acb836928de

## Summary by Sourcery

Bug Fixes:
- Handle empty string and null inputs in formatNumber to return an empty string before NaN check