### PR TITLE
Fix A–Z anchoring and subtotal grouping key handling

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -476,12 +476,15 @@ class DrillDowner {
             if(i === 0) tr.classList.add('drillDowner_first_group');
 
             let anchorHtml = '';
-            if(level === 0 && key.length > 0) {
-                const firstLetter = key.charAt(0).toUpperCase();
-                if(!this.azAnchoredLetters.has(firstLetter)) {
-                    const anchorId = this.options.idPrefix + "az" + firstLetter;
-                    anchorHtml = `<span id="${anchorId}" class="drillDowner_az_anchor"></span>`;
-                    this.azAnchoredLetters.add(firstLetter);
+            if(level === 0) {
+                const keyString = key == null ? '' : String(key);
+                if(keyString.length > 0) {
+                    const firstLetter = keyString.charAt(0).toUpperCase();
+                    if(!this.azAnchoredLetters.has(firstLetter)) {
+                        const anchorId = this.options.idPrefix + "az" + firstLetter;
+                        anchorHtml = `<span id="${anchorId}" class="drillDowner_az_anchor"></span>`;
+                        this.azAnchoredLetters.add(firstLetter);
+                    }
                 }
             }
 
@@ -512,7 +515,8 @@ class DrillDowner {
                     const subtotals = {};
                     groupData.forEach(row => {
                         const k = row[subTotalBy];
-                        if(row[totalCol] != null && k) {
+                        const hasKey = k === null ? false : true;
+                        if(row[totalCol] != null && hasKey) {
                             subtotals[k] = (subtotals[k] || 0) + row[totalCol];
                         }
                     });
@@ -655,7 +659,8 @@ class DrillDowner {
                 const subtotals = {};
                 this.dataArr.forEach(row => {
                     const key = row[subTotalBy];
-                    if (row[totalCol] != null && key) {
+                    const hasKey = key === null ? false : true;
+                    if (row[totalCol] != null && hasKey) {
                         subtotals[key] = (subtotals[key] || 0) + row[totalCol];
                     }
                 });


### PR DESCRIPTION
### Motivation
- Two bugs caused crashes or incorrect subtotaling: A–Z anchoring could crash on non-string or null group keys when extracting the first letter, and subtotal/grand-total aggregation silently dropped falsy grouping keys like `0` or empty string.

### Description
- In `src/DrillDowner.js` guard A–Z anchor generation in row-building by converting `key` to a string with `String(key)` and skipping empty-key values before reading the first letter (affects anchor generation in the flat row builder).
- Change subtotal aggregation logic in per-group totals and grand totals (used in the row builder and in `_calculateGrandTotals`) to only exclude `null` grouping keys so falsy but valid keys such as `0` or `''` are preserved in subtotals.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d3488c8f883309224c16dfd36c11a)

## Summary by Sourcery

Handle A–Z anchors and subtotal aggregation more robustly for non-string and falsy grouping keys.

Bug Fixes:
- Prevent A–Z anchor generation from crashing when group keys are null or non-strings by safely stringifying keys and skipping empty values.
- Ensure subtotal and grand-total calculations retain falsy but valid grouping keys like 0 and empty strings while still excluding null keys.