### PR TITLE
Add simple/medium/advanced examples and improve leafRenderer across demos

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,12 @@ const dd = new DrillDowner(container, dataArr, options)
 
 ---
 
+## Example Gallery
+
+- `examples/Simple_Example.html` — minimal grouped setup with `leafRenderer`.
+- `examples/Medium_Example.html` — grouped + ledger + controls + A–Z bar.
+- `examples/Advanced_Example.html` — running balance, label click callback, and custom leaf labels.
+
 ## Documentation
 
 - **[Full API Reference](docs/drilldowner_docs.md)** — all options, colProperties, methods, CSS classes, and examples

--- a/examples/Advanced_Example.html
+++ b/examples/Advanced_Example.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DrillDowner - Advanced Example</title>
+  <link href="../src/drilldowner.css" rel="stylesheet" type="text/css"/>
+  <script src="../src/DrillDowner.js"></script>
+</head>
+<body>
+<h2>Advanced Example (Running Balance + Click Context + Leaf Renderer)</h2>
+<div id="advanced-controls"></div>
+<div style="display:flex; gap:16px;">
+  <div id="advanced-az"></div>
+  <div id="advanced-table" style="flex:1;"></div>
+</div>
+<pre id="advanced-log" style="background:#f7f7f7; padding:10px; margin-top:10px;">Click any label to inspect context.</pre>
+
+<script>
+  const tx = [
+    { account: "Operating", month: "2024-01", category: "Income", desc: "Invoice 1001", credit: 5200, debit: 0 },
+    { account: "Operating", month: "2024-01", category: "Expense", desc: "Cloud Hosting", credit: 0, debit: 480 },
+    { account: "Operating", month: "2024-02", category: "Income", desc: "Invoice 1008", credit: 4100, debit: 0 },
+    { account: "Savings", month: "2024-02", category: "Income", desc: "Interest", credit: 90, debit: 0 },
+    { account: "Savings", month: "2024-02", category: "Expense", desc: "Bank Fee", credit: 0, debit: 12 }
+  ];
+
+  new DrillDowner('#advanced-table', tx, {
+    groupOrder: ["account", "month", "category"],
+    groupOrderCombinations: [
+      ["account", "month", "category"],
+      ["category", "account", "month"]
+    ],
+    totals: ["credit", "debit", "balance"],
+    columns: ["desc"],
+    ledger: [
+      { label: "Ledger: by Month", cols: ["month", "account", "desc", "credit", "debit", "balance"], sort: ["month"] }
+    ],
+    controlsSelector: '#advanced-controls',
+    azBarSelector: '#advanced-az',
+    colProperties: {
+      account: { label: "Account", icon: "🏦" },
+      month: { label: "Month", icon: "🗓️" },
+      category: { label: "Category", icon: "📚" },
+      desc: { label: "Description" },
+      credit: { label: "Credit", formatter: (v) => v ? `+$${DrillDowner.formatNumber(v, 2)}` : '-' },
+      debit: { label: "Debit", formatter: (v) => v ? `-$${DrillDowner.formatNumber(v, 2)}` : '-' },
+      balance: {
+        label: "Running Balance",
+        balanceBehavior: { initialBalance: 10000, add: ["credit"], subtract: ["debit"] },
+        formatter: (v) => `$${DrillDowner.formatNumber(v, 2)}`
+      }
+    },
+    leafRenderer: (item) => `${item.category} <small style="color:#666">• ${item.desc}</small>`,
+    onLabelClick: (ctx) => {
+      document.getElementById('advanced-log').textContent = JSON.stringify({
+        label: ctx.label,
+        level: ctx.level,
+        path: ctx.hierarchyMap
+      }, null, 2);
+    }
+  });
+</script>
+</body>
+</html>

--- a/examples/BalanceExample.html
+++ b/examples/BalanceExample.html
@@ -185,6 +185,8 @@
             azBarSelector: '#az-bar',
 
             // Optional: Pre-defined groupings for the dropdown
+            leafRenderer: (item) => `${item.desc} <small style="color:#666">(${item.date})</small>`,
+
             groupOrderCombinations: [
                 ["category", "type"],
                 ["type", "category"],

--- a/examples/BalanceExample_2.html
+++ b/examples/BalanceExample_2.html
@@ -65,7 +65,8 @@
           }
         }
       },
-      controlsSelector: '#table-controls'
+      controlsSelector: '#table-controls',
+      leafRenderer: (item) => `${item.desc} <small style="color:#666">(${item.date})</small>`
     });
   });
 </script>

--- a/examples/Books_example.html
+++ b/examples/Books_example.html
@@ -79,6 +79,8 @@
             price:  { label: "Unit Price", decimals: 2, formatter: (v) => fmtMoney(v) },
         },
 
+        leafRenderer: (item) => `${item.title} <small style="color:#666">by ${item.author}</small>`,
+
         showGrandTotals: true,
     });
 

--- a/examples/DrillDowner_Example.html
+++ b/examples/DrillDowner_Example.html
@@ -128,7 +128,10 @@
                 },
              //   groupOrderCombinations:[["brand","product"],["category","product"],["category","brand","product"]],
                 controlsSelector: '#table-controls',
-                azBarSelector: '#az-bar'
+                azBarSelector: '#az-bar',
+                leafRenderer: function(item) {
+                    return `${item.item} <small style="color:#666">(${item.brand})</small>`;
+                }
             });
             console.log("drillDowner", drillDowner);
         });

--- a/examples/LabelClickCallback.html
+++ b/examples/LabelClickCallback.html
@@ -68,7 +68,9 @@
             // Callback triggered by internal DrillDowner logic
             onLabelClick: (ctx) => {
                 openDialog(ctx);
-            }
+            },
+
+            leafRenderer: (item) => `${item.Product} <small style="color:#666">(Qty: ${item.Qty})</small>`
         });
     });
 

--- a/examples/LedgerDrillExample.html
+++ b/examples/LedgerDrillExample.html
@@ -144,7 +144,10 @@
             ],
 
             controlsSelector: '#table-controls',
-            azBarSelector: '#az-bar'
+            azBarSelector: '#az-bar',
+            leafRenderer: function(item) {
+                return `${item.product} <small style="color:#666">${item.info || ''}</small>`;
+            }
         });
         console.log("drillDowner initialized", drillDowner);
     });

--- a/examples/Medium_Example.html
+++ b/examples/Medium_Example.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DrillDowner - Medium Example</title>
+  <link href="../src/drilldowner.css" rel="stylesheet" type="text/css"/>
+  <script src="../src/DrillDowner.js"></script>
+</head>
+<body>
+<h2>Medium Example (Grouped + Ledger + Controls)</h2>
+<div id="medium-controls"></div>
+<div style="display:flex; gap:16px;">
+  <div id="medium-az"></div>
+  <div id="medium-table" style="flex:1;"></div>
+</div>
+
+<script>
+  const orders = [
+    { region: "North", customer: "Atlas Co", order: "A-100", status: "Shipped", units: 30, amount: 12500 },
+    { region: "North", customer: "Atlas Co", order: "A-102", status: "Pending", units: 12, amount: 3900 },
+    { region: "North", customer: "Beacon LLC", order: "B-210", status: "Shipped", units: 6, amount: 1800 },
+    { region: "South", customer: "Crane Ltd", order: "C-005", status: "Invoiced", units: 18, amount: 6400 },
+    { region: "South", customer: "Crane Ltd", order: "C-010", status: "Pending", units: 5, amount: 1200 }
+  ];
+
+  new DrillDowner('#medium-table', orders, {
+    groupOrder: ["region", "customer", "order"],
+    groupOrderCombinations: [
+      ["region", "customer", "order"],
+      ["customer", "region", "order"]
+    ],
+    totals: ["units", "amount"],
+    columns: ["status"],
+    ledger: [
+      { label: "Ledger: Latest Amount", cols: ["region", "customer", "order", "status"], sort: ["-amount"] }
+    ],
+    controlsSelector: '#medium-controls',
+    azBarSelector: '#medium-az',
+    colProperties: {
+      region: { label: "Region", icon: "🌎" },
+      customer: { label: "Customer", icon: "🏢" },
+      order: { label: "Order", icon: "🧾" },
+      status: { label: "Status", togglesUp: true },
+      units: { label: "Units", decimals: 0 },
+      amount: { label: "Amount", formatter: (v) => `$${DrillDowner.formatNumber(v, 2)}` }
+    },
+    leafRenderer: (item) => `${item.order} <small style="color:#666">for ${item.customer}</small>`
+  });
+</script>
+</body>
+</html>

--- a/examples/Simple_Example.html
+++ b/examples/Simple_Example.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DrillDowner - Simple Example</title>
+  <link href="../src/drilldowner.css" rel="stylesheet" type="text/css"/>
+  <script src="../src/DrillDowner.js"></script>
+</head>
+<body>
+<h2>Simple DrillDowner Example</h2>
+<div id="simple-table"></div>
+
+<script>
+  const data = [
+    { department: "Electronics", product: "USB-C Charger", qty: 14, price: 24.99 },
+    { department: "Electronics", product: "Bluetooth Speaker", qty: 8, price: 79.00 },
+    { department: "Books", product: "JavaScript Basics", qty: 22, price: 19.50 },
+    { department: "Books", product: "UI Design Guide", qty: 9, price: 35.00 }
+  ];
+
+  new DrillDowner('#simple-table', data, {
+    groupOrder: ["department", "product"],
+    totals: ["qty", "price"],
+    colProperties: {
+      department: { label: "Department", icon: "🗂️" },
+      product: { label: "Product", icon: "📦" },
+      qty: { label: "Stock", decimals: 0 },
+      price: { label: "Unit Price", formatter: (v) => `$${DrillDowner.formatNumber(v, 2)}` }
+    },
+    leafRenderer: (item) => `${item.product} <small style="color:#666">(${item.qty} units)</small>`
+  });
+</script>
+</body>
+</html>

--- a/examples/TogglesUp_Example.html
+++ b/examples/TogglesUp_Example.html
@@ -35,7 +35,8 @@
             product:  { label: "Product" },
             status:   { label: "Status" },          // togglesUp not enabled
             qty:      { label: "Qty", decimals: 0 },
-        }
+        },
+        leafRenderer: (item) => `${item.product} <small style="color:#666">(${item.status})</small>`
     });
 
     // 2) togglesUp ON: group row "status" shows combined unique statuses
@@ -49,7 +50,8 @@
             product:  { label: "Product" },
             status:   { label: "Status", togglesUp: true }, // <-- here
             qty:      { label: "Qty", decimals: 0 },
-        }
+        },
+        leafRenderer: (item) => `${item.product} <small style="color:#666">(${item.status})</small>`
     });
 
     /*
@@ -69,28 +71,30 @@
 
     // 1) togglesUp OFF: group row cells for "status" are blank
     new DrillDowner("#dd_off", data, {
-        groupOrder: ["category"],
-        columns: ["product", "status"],
+        groupOrder: ["category", "product"],
+        columns: ["status"],
         totals: ["qty"],
         colProperties: {
             category: { label: "Category" },
             product:  { label: "Product" },
             status:   { label: "Status" },          // togglesUp not enabled
             qty:      { label: "Qty", decimals: 0 },
-        }
+        },
+        leafRenderer: (item) => `${item.product} <small style="color:#666">(${item.status})</small>`
     });
 
     // 2) togglesUp ON: group row "status" shows combined unique statuses
     new DrillDowner("#dd_on", data, {
-        groupOrder: ["category"],
-        columns: ["product", "status"],
+        groupOrder: ["category", "product"],
+        columns: ["status"],
         totals: ["qty"],
         colProperties: {
             category: { label: "Category" },
             product:  { label: "Product" },
             status:   { label: "Status", togglesUp: true }, // <-- here
             qty:      { label: "Qty", decimals: 0 },
-        }
+        },
+        leafRenderer: (item) => `${item.product} <small style="color:#666">(${item.status})</small>`
     });
 
     /*

--- a/examples/example.html
+++ b/examples/example.html
@@ -163,6 +163,11 @@
                 status:   { label: "Status", formatter: formatStatus }
             },
 
+            // Make leaf rows more informative than a plain product string
+            leafRenderer: (item) => {
+                return `${item.product} <small style="color:#64748b">(${item.rep})</small>`;
+            },
+
             showGrandTotals: true
         });
     });

--- a/index.html
+++ b/index.html
@@ -163,6 +163,8 @@
                 status:   { label: "Status", formatter: formatStatus }
             },
 
+            leafRenderer: (item) => `${item.product} <small style="color:#64748b">(${item.rep})</small>`,
+
             showGrandTotals: true
         });
     });


### PR DESCRIPTION
### Motivation
- Provide clear, progressive usage examples (simple → medium → advanced) to help users learn DrillDowner in stages. 
- Improve the visual usefulness of leaf rows so example apps show meaningful final-row labels instead of raw field strings. 
- Surface a small example gallery in the README so the new demos are discoverable. 

### Description
- Added three runnable examples: `examples/Simple_Example.html`, `examples/Medium_Example.html`, and `examples/Advanced_Example.html` demonstrating minimal, intermediate and advanced uses respectively. 
- Updated existing demos (including `index.html` and several `examples/*.html`) to include a `leafRenderer` that produces richer leaf-row label HTML and made `examples/TogglesUp_Example.html` use a real leaf level (`category -> product`). 
- Added an “Example Gallery” section to `README.md` linking the new examples, and adjusted other examples to show good `leafRenderer` patterns (no core library changes). 

### Testing
- Built distributables with `npm run build` and the build completed successfully. 
- Confirmed all example files contain a `leafRenderer` using `rg`/`rg --files` checks, which reported the expected occurrences. 
- Served the repository locally with `python3 -m http.server` and captured a rendering verification screenshot of `examples/Medium_Example.html` using an automated browser script, which completed successfully. 
- Performed a quick smoke test by opening the medium example in a browser to verify controls, ledger view and leaf labels render as intended, and it behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5b4ae801c8330aa969d3eaeaeeec1)

## Summary by Sourcery

Add progressively complex DrillDowner HTML examples and standardize richer leaf row rendering across demos.

New Features:
- Introduce simple, medium, and advanced DrillDowner example pages showcasing grouped views, ledger mode, controls, A–Z bar, running balances, and label click callbacks.
- Add an example gallery section in the README linking the new example pages.

Enhancements:
- Update existing demo pages and the main index example to use a leafRenderer for more informative leaf labels instead of plain field strings.
- Adjust the TogglesUp example configuration to use a real leaf grouping level for product rows.