### PR TITLE
Add examples section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,23 @@
     </div>
 </div>
 
+<div style="max-width: 1200px; margin: 0 auto 1.5rem; background: white; border-radius: 8px; box-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1); padding: 20px;">
+    <h2 style="margin: 0 0 12px; font-size: 1.1rem; color: #0f172a;">Examples</h2>
+    <ul style="margin: 0; padding: 0; list-style: none; display: grid; grid-template-columns: repeat(auto-fill, minmax(340px, 1fr)); gap: 8px;">
+        <li><a href="examples/Simple_Example.html" style="color: var(--primary); font-weight: 500;">Simple Example</a> &mdash; <span style="color:#64748b">Basic product inventory organized by department with totals and formatting.</span></li>
+        <li><a href="examples/Medium_Example.html" style="color: var(--primary); font-weight: 500;">Medium Example</a> &mdash; <span style="color:#64748b">Order management with regional customer grouping and switchable view modes.</span></li>
+        <li><a href="examples/Advanced_Example.html" style="color: var(--primary); font-weight: 500;">Advanced Example</a> &mdash; <span style="color:#64748b">Financial ledger with running balance, multiple views, A-Z navigation, and click callbacks.</span></li>
+        <li><a href="examples/DrillDowner_Example.html" style="color: var(--primary); font-weight: 500;">DrillDowner Example</a> &mdash; <span style="color:#64748b">Comprehensive inventory with multiple grouping hierarchies and A-Z navigation sidebar.</span></li>
+        <li><a href="examples/Books_example.html" style="color: var(--primary); font-weight: 500;">Books Example</a> &mdash; <span style="color:#64748b">Book inventory with multiple groupings, custom sorting, and formatted currency totals.</span></li>
+        <li><a href="examples/TogglesUp_Example.html" style="color: var(--primary); font-weight: 500;">TogglesUp Example</a> &mdash; <span style="color:#64748b">Shows how unique child values bubble up and appear in parent group rows.</span></li>
+        <li><a href="examples/LabelClickCallback.html" style="color: var(--primary); font-weight: 500;">Label Click Callback</a> &mdash; <span style="color:#64748b">Captures clicks on group labels and shows detailed context in a modal dialog.</span></li>
+        <li><a href="examples/BalanceExample.html" style="color: var(--primary); font-weight: 500;">Balance Example</a> &mdash; <span style="color:#64748b">Bank statement with row-by-row running balance in ledger mode and net totals in group view.</span></li>
+        <li><a href="examples/BalanceExample_2.html" style="color: var(--primary); font-weight: 500;">Balance Example 2</a> &mdash; <span style="color:#64748b">Income/expense statement with running balances that accumulate across grouped and ledger views.</span></li>
+        <li><a href="examples/LedgerDrillExample.html" style="color: var(--primary); font-weight: 500;">Ledger Drill Example</a> &mdash; <span style="color:#64748b">Transaction ledger sorted latest-first with category analysis and running balance.</span></li>
+        <li><a href="examples/example.html" style="color: var(--primary); font-weight: 500;">Example</a> &mdash; <span style="color:#64748b">Sales dashboard with region-to-product hierarchies, formatted currency, and status badges.</span></li>
+    </ul>
+</div>
+
 <div class="demo-wrapper">
     <div id="dd-controls"></div>
 


### PR DESCRIPTION
## Summary
Added a new "Examples" section to the homepage that showcases all available DrillDowner.js examples with descriptions.

## Changes
- Added a new styled section below the main content area featuring a grid layout of example links
- Included 11 example links with descriptive text for each:
  - Simple Example (basic product inventory)
  - Medium Example (order management)
  - Advanced Example (financial ledger)
  - DrillDowner Example (comprehensive inventory)
  - Books Example (book inventory)
  - TogglesUp Example (child value bubbling)
  - Label Click Callback (modal interactions)
  - Balance Example (bank statement)
  - Balance Example 2 (income/expense statement)
  - Ledger Drill Example (transaction ledger)
  - Example (sales dashboard)

## Implementation Details
- Used inline CSS styling consistent with the existing design system (white background, rounded corners, shadow)
- Implemented responsive grid layout with `grid-template-columns: repeat(auto-fill, minmax(340px, 1fr))` for mobile-friendly display
- Each example includes a linked title and descriptive subtitle explaining its use case
- Styled with existing CSS variables (primary color) and Tailwind-inspired color palette for consistency

https://claude.ai/code/session_01CDQyuNEKidR7WNQYNkDuUJ

## Summary by Sourcery

New Features:
- Introduce an Examples section on the homepage that lists and describes all available DrillDowner.js example pages in a responsive grid.