### PR TITLE
Add drag-and-drop reordering for breadcrumb navigation

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -331,11 +331,10 @@ class DrillDowner {
     _renderBreadcrumbs(nav) {
         nav.innerHTML = '';
         const items = [];
+        const isDraggable = this.options.groupOrder.length > 1;
         if(this.options.groupOrder.length > 0) {
             this.options.groupOrder.forEach((key, i) => {
-                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}">
-                    <span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span>
-                </button>`);
+                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}"${isDraggable ? ' draggable="true"' : ''}>${isDraggable ? '<span class="drillDowner_drag_handle" aria-hidden="true"></span>' : ''}<span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`);
                 if(i < this.options.groupOrder.length - 1) {
                     items.push(`<button type="button" class="drillDowner_breadcrumb_arrow drillDowner_collapsed" data-arrow-level="${i}">
                         <span class="drillDowner_arrow_icon">▶</span>
@@ -359,6 +358,169 @@ class DrillDowner {
                 this.showToLevel(btn.classList.contains('drillDowner_expanded') ? lvl : lvl + 1);
             };
         });
+
+        if(isDraggable) this._setupBreadcrumbDrag(nav);
+    }
+
+    _setupBreadcrumbDrag(nav) {
+        const self = this;
+        let dragSrcLevel = null;
+
+        nav.querySelectorAll('.drillDowner_breadcrumb_item[data-level]').forEach(btn => {
+            // ── HTML5 Drag & Drop – desktop + Safari Mac ───────────────────
+            btn.addEventListener('dragstart', (e) => {
+                dragSrcLevel = parseInt(btn.dataset.level);
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', String(dragSrcLevel));
+                // Delay class so the drag ghost captures the un-dimmed state
+                setTimeout(() => btn.classList.add('drillDowner_dragging'), 0);
+            });
+
+            btn.addEventListener('dragend', () => {
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                dragSrcLevel = null;
+            });
+
+            btn.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+            });
+
+            btn.addEventListener('dragenter', (e) => {
+                e.preventDefault();
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                if(parseInt(btn.dataset.level) !== dragSrcLevel)
+                    btn.classList.add('drillDowner_drag_over');
+            });
+
+            btn.addEventListener('dragleave', () => {
+                btn.classList.remove('drillDowner_drag_over');
+            });
+
+            btn.addEventListener('drop', (e) => {
+                e.preventDefault();
+                const fromIdx = parseInt(e.dataTransfer.getData('text/plain'));
+                const toIdx   = parseInt(btn.dataset.level);
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
+                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
+                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+            });
+
+            // ── Touch – iOS Safari & touch screens ────────────────────────
+            let ts = null; // touch state
+
+            btn.addEventListener('touchstart', (e) => {
+                if(e.touches.length !== 1) return;
+                const t = e.touches[0];
+                ts = { startX: t.clientX, startY: t.clientY, dragging: false, target: null };
+            }, { passive: true });
+
+            btn.addEventListener('touchmove', (e) => {
+                if(!ts) return;
+                const t = e.touches[0];
+                const dx = Math.abs(t.clientX - ts.startX);
+                const dy = Math.abs(t.clientY - ts.startY);
+                if(!ts.dragging && (dx > 8 || dy > 8)) {
+                    ts.dragging = true;
+                    btn.classList.add('drillDowner_dragging');
+                }
+                if(!ts.dragging) return;
+                e.preventDefault(); // prevent scroll while dragging
+
+                const el = document.elementFromPoint(t.clientX, t.clientY);
+                const tgt = el && el.closest('.drillDowner_breadcrumb_item[data-level]');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                if(tgt && tgt !== btn) {
+                    tgt.classList.add('drillDowner_drag_over');
+                    ts.target = tgt;
+                } else {
+                    ts.target = null;
+                }
+            }, { passive: false });
+
+            btn.addEventListener('touchend', (e) => {
+                if(!ts) return;
+                const { dragging, target } = ts;
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                ts = null;
+                if(!dragging || !target) return;
+                e.preventDefault(); // suppress synthesised click after drag
+                const fromIdx = parseInt(btn.dataset.level);
+                const toIdx   = parseInt(target.dataset.level);
+                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
+                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+            });
+
+            btn.addEventListener('touchcancel', () => {
+                if(!ts) return;
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                ts = null;
+            });
+        });
+    }
+
+    _reorderArray(arr, fromIdx, toIdx) {
+        const result = [...arr];
+        const [item] = result.splice(fromIdx, 1);
+        result.splice(toIdx, 0, item);
+        return result;
+    }
+
+    _applyNewGroupOrder(newOrder) {
+        const oldOrder = [...this.options.groupOrder];
+        this.options.groupOrder = newOrder;
+        this.activeLedgerIndex = -1;
+        this.options.columns = [...this._defaultColumns];
+
+        // Sync the select box silently (no 'change' event – avoids double render)
+        const select = this.controls && this.controls.querySelector('select.drillDowner_modern_select');
+        if(select) {
+            const targetValue = newOrder.join(',');
+            let found = false;
+
+            if(this.options.groupOrderCombinations) {
+                for(let i = 0; i < this.options.groupOrderCombinations.length; i++) {
+                    if(this.options.groupOrderCombinations[i].join(',') === targetValue) {
+                        select.selectedIndex = i;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if(!found) {
+                for(let i = 0; i < select.options.length; i++) {
+                    if(select.options[i].value === targetValue) {
+                        select.selectedIndex = i;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if(!found) {
+                const label = newOrder.map(col => this._getColHeader(col)).join(' → ');
+                select.add(new Option(label, targetValue));
+                select.value = targetValue;
+            }
+        }
+
+        if(typeof this.options.onGroupOrderChange === 'function')
+            this.options.onGroupOrderChange(newOrder, oldOrder, this);
+
+        // Re-render breadcrumbs then table
+        const nav = this.controls && this.controls.querySelector('.drillDowner_breadcrumb_nav');
+        if(nav) this._renderBreadcrumbs(nav);
+        this.render();
     }
 
     _updateBreadcrumbVisuals(level) {

--- a/src/drilldowner.css
+++ b/src/drilldowner.css
@@ -104,23 +104,89 @@
 }
 
 .drillDowner_breadcrumb_item {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     cursor: pointer;
-    padding: 8px 12px;
+    padding: 5px 10px;
     border-radius: 6px;
-    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
     font-weight: 500;
+    font-size: 13px;
     position: relative;
     user-select: none;
     background: #f8fafc;
     color: #374151;
+    white-space: nowrap;
+    line-height: 1.4;
 }
 
 .drillDowner_breadcrumb_item:hover {
-    background: #f1f5f9;
-    transform: translateY(-1px);
+    background: #e8f0fe;
+    border-color: #c7d7fd;
     color: #1f2937;
+}
+
+/* Drag handle – two columns of dots, only visible on hover (desktop) */
+.drillDowner_drag_handle {
+    display: inline-block;
+    width: 8px;
+    height: 14px;
+    margin-right: 5px;
+    flex-shrink: 0;
+    background-image:
+        radial-gradient(circle, #9ca3af 1.2px, transparent 1.2px),
+        radial-gradient(circle, #9ca3af 1.2px, transparent 1.2px);
+    background-size: 4px 4px, 4px 4px;
+    background-position: 0 0, 4px 2px;
+    background-repeat: repeat-y, repeat-y;
+    opacity: 0;
+    transition: opacity 0.15s;
+    vertical-align: middle;
+    cursor: grab;
+}
+
+.drillDowner_breadcrumb_item:hover .drillDowner_drag_handle {
+    opacity: 0.55;
+}
+
+/* Drag states */
+.drillDowner_breadcrumb_item[draggable="true"] {
+    cursor: grab;
+}
+
+.drillDowner_breadcrumb_item.drillDowner_dragging {
+    opacity: 0.45;
+    cursor: grabbing;
+}
+
+.drillDowner_breadcrumb_item.drillDowner_drag_over {
+    background: #dbeafe;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+/* Touch / coarse pointer – larger tap targets */
+@media (pointer: coarse) {
+    .drillDowner_breadcrumb_item {
+        padding: 10px 14px;
+        font-size: 15px;
+        min-height: 44px;
+    }
+
+    .drillDowner_drag_handle {
+        width: 10px;
+        height: 18px;
+        margin-right: 7px;
+        opacity: 0.5; /* always visible on touch */
+    }
+
+    .drillDowner_breadcrumb_arrow {
+        min-width: 36px;
+        height: 36px;
+        font-size: 15px;
+        margin: 0 4px;
+    }
 }
 
 /* Interactive Arrow States */


### PR DESCRIPTION
## Summary
This PR adds drag-and-drop functionality to breadcrumb items, allowing users to reorder the grouping hierarchy on both desktop and touch devices. The implementation includes full HTML5 drag-and-drop support for desktop browsers and custom touch event handling for mobile devices.

## Key Changes

- **Breadcrumb drag-and-drop UI**: Added `draggable` attribute and visual drag handle to breadcrumb items when multiple grouping options are available
- **Desktop drag support**: Implemented HTML5 Drag and Drop API with visual feedback (dragging state, drop target highlighting)
- **Touch device support**: Added comprehensive touch event handling (touchstart, touchmove, touchend, touchcancel) with gesture detection (8px threshold) to distinguish drag from tap
- **Group order reordering**: New `_reorderArray()` method to handle array element swapping and `_applyNewGroupOrder()` method to apply changes, update the select dropdown, trigger callbacks, and re-render
- **Styling enhancements**: 
  - Updated breadcrumb item styling with smaller padding and inline-flex layout
  - Added visual drag handle (two-column dot pattern) that appears on hover (desktop) or always visible (touch)
  - Added drag state styles (opacity, border, shadow) for visual feedback
  - Responsive touch-friendly sizing with larger tap targets (44px minimum height)
  - Improved transitions and color scheme

## Implementation Details

- Drag functionality only activates when `groupOrder.length > 1` to avoid unnecessary overhead
- Touch implementation uses `elementFromPoint()` to detect drop targets during drag
- Select dropdown is synced silently (no change event) to avoid double rendering
- Supports custom `onGroupOrderChange` callback for external state management
- Drag handle uses CSS radial gradients for a clean, accessible visual indicator

https://claude.ai/code/session_01KU45wkWx8oScqazVqk2Bps

## Summary by Sourcery

Add drag-and-drop reordering to breadcrumb navigation with synchronized group order state and updated visuals.

New Features:
- Enable drag-and-drop reordering of breadcrumb items when multiple group levels are available.
- Introduce keyboard-independent drag handles on breadcrumb items for pointer-based reordering.
- Provide support for reordering group hierarchy via touch interactions on mobile devices.

Enhancements:
- Refine breadcrumb styling for denser layout, improved hover states, and clearer drag affordances.
- Ensure breadcrumb group order changes propagate to the select control and table rendering while supporting an optional onGroupOrderChange callback.