### PR TITLE
Claude/dimension parking area 5v t bs

### DIFF
--- a/examples/Parking_Area_Example.html
+++ b/examples/Parking_Area_Example.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>DrillDowner – Dimension Parking Area</title>
+  <link href="../src/drilldowner.css" rel="stylesheet" type="text/css"/>
+  <script src="../src/DrillDowner.js"></script>
+</head>
+<body>
+<h2>Dimension Parking Area Example</h2>
+<p>
+  Drag the active dimension buttons (top row) to <strong>reorder</strong> them.<br>
+  Drag a button to the parking strip (right of the "Group by" select) to <strong>remove it from grouping</strong>.<br>
+  Drag a parked dimension back onto the active row to <strong>re-add it</strong>.
+</p>
+
+<div id="controls"></div>
+<div id="table"></div>
+
+<script>
+  const data = [
+    { region: "North", rep: "Alice",   customer: "Acme",    product: "Widget",  sales: 1200, cost: 800 },
+    { region: "North", rep: "Alice",   customer: "Globex",  product: "Gadget",  sales: 950,  cost: 600 },
+    { region: "North", rep: "Bob",     customer: "Acme",    product: "Gadget",  sales: 800,  cost: 500 },
+    { region: "South", rep: "Carol",   customer: "Initech", product: "Widget",  sales: 1500, cost: 900 },
+    { region: "South", rep: "Carol",   customer: "Globex",  product: "Widget",  sales: 600,  cost: 400 },
+    { region: "South", rep: "Dave",    customer: "Initech", product: "Gadget",  sales: 1100, cost: 700 },
+    { region: "East",  rep: "Eve",     customer: "Hooli",   product: "Widget",  sales: 750,  cost: 450 },
+    { region: "East",  rep: "Eve",     customer: "Acme",    product: "Gadget",  sales: 880,  cost: 560 },
+    { region: "West",  rep: "Frank",   customer: "Hooli",   product: "Widget",  sales: 1300, cost: 820 },
+    { region: "West",  rep: "Frank",   customer: "Globex",  product: "Gadget",  sales: 970,  cost: 610 },
+  ];
+
+  new DrillDowner('#table', data, {
+    // All four dimensions available; start with three active, one parked
+    availableDimensions: ["region", "rep", "customer", "product"],
+    groupOrder:          ["region", "rep", "customer"],   // product starts parked
+
+    totals:  ["sales", "cost"],
+    columns: [],
+
+    controlsSelector: '#controls',
+
+    colProperties: {
+      region:   { label: "Region",   icon: "🌎" },
+      rep:      { label: "Rep",      icon: "👤" },
+      customer: { label: "Customer", icon: "🏢" },
+      product:  { label: "Product",  icon: "📦" },
+      sales:    { label: "Sales",    decimals: 0 },
+      cost:     { label: "Cost",     decimals: 0 },
+    },
+
+    onGroupOrderChange: (newOrder, oldOrder) => {
+      console.log('Group order changed:', oldOrder, '→', newOrder);
+    }
+  });
+</script>
+</body>
+</html>

--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -13,6 +13,7 @@ class DrillDowner {
             colProperties: {},
             groupOrder: [],
             groupOrderCombinations: null,
+            availableDimensions: null, // all groupable dim keys; enables parking area when set
             ledger: [],
             idPrefix: 'drillDowner' + Math.random().toString(36).slice(2) + '_',
             azBarSelector: null,
@@ -268,12 +269,16 @@ class DrillDowner {
             this.controls.innerHTML = `
                 <div class="drillDowner_controls_container">
                     <div class="drillDowner_breadcrumb_nav"></div>
-                    <div class="drillDowner_grouping_controls"></div>
+                    <div class="drillDowner_grouping_controls">
+                        ${this.options.availableDimensions ? '<div class="drillDowner_parking_area"></div>' : ''}
+                    </div>
                 </div>`;
             container = this.controls.querySelector('.drillDowner_controls_container');
 
             this._renderGroupingSelect(container.querySelector('.drillDowner_grouping_controls'));
             this._renderBreadcrumbs(container.querySelector('.drillDowner_breadcrumb_nav'));
+            this._renderParkingArea();
+            this._setupDndOnControls(); // HTML5 DnD via delegation – attached once
         }
     }
 
@@ -324,6 +329,7 @@ class DrillDowner {
             }
 
             this._renderBreadcrumbs(this.controls.querySelector('.drillDowner_breadcrumb_nav'));
+            this._renderParkingArea();
             this.render();
         });
     }
@@ -331,10 +337,13 @@ class DrillDowner {
     _renderBreadcrumbs(nav) {
         nav.innerHTML = '';
         const items = [];
-        const isDraggable = this.options.groupOrder.length > 1;
+        // Draggable when: reordering (2+ active) OR parking area exists (can eject dims)
+        const hasParking = !!this.options.availableDimensions;
+        const isDraggable = this.options.groupOrder.length > 1 || (hasParking && this.options.groupOrder.length >= 1);
+
         if(this.options.groupOrder.length > 0) {
             this.options.groupOrder.forEach((key, i) => {
-                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}"${isDraggable ? ' draggable="true"' : ''}>${isDraggable ? '<span class="drillDowner_drag_handle" aria-hidden="true"></span>' : ''}<span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`);
+                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}" data-dim="${key}"${isDraggable ? ' draggable="true"' : ''}>${isDraggable ? '<span class="drillDowner_drag_handle" aria-hidden="true"></span>' : ''}<span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`);
                 if(i < this.options.groupOrder.length - 1) {
                     items.push(`<button type="button" class="drillDowner_breadcrumb_arrow drillDowner_collapsed" data-arrow-level="${i}">
                         <span class="drillDowner_arrow_icon">▶</span>
@@ -344,6 +353,8 @@ class DrillDowner {
         } else if(this.activeLedgerIndex >= 0) {
             const label = this.options.ledger[this.activeLedgerIndex].label;
             items.push(`<span class="drillDowner_breadcrumb_item" style="cursor:default"><b>${label}</b></span>`);
+        } else if(hasParking) {
+            items.push(`<span class="drillDowner_nav_empty_hint">drag a dimension here to group</span>`);
         }
         nav.innerHTML = items.join('');
 
@@ -359,111 +370,196 @@ class DrillDowner {
             };
         });
 
-        if(isDraggable) this._setupBreadcrumbDrag(nav);
+        if(isDraggable || hasParking) this._setupTouchOnDraggables(nav);
     }
 
-    _setupBreadcrumbDrag(nav) {
+    // ── HTML5 DnD via event delegation – wired once on this.controls ──────────
+    _setupDndOnControls() {
+        if(!this.controls || this._dndListenersAttached) return;
+        this._dndListenersAttached = true;
         const self = this;
-        let dragSrcLevel = null;
 
-        nav.querySelectorAll('.drillDowner_breadcrumb_item[data-level]').forEach(btn => {
-            // ── HTML5 Drag & Drop – desktop + Safari Mac ───────────────────
-            btn.addEventListener('dragstart', (e) => {
-                dragSrcLevel = parseInt(btn.dataset.level);
+        this.controls.addEventListener('dragstart', (e) => {
+            const navBtn  = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
+            const parkBtn = e.target.closest('.drillDowner_parking_item[data-dim]');
+            if(navBtn) {
+                self._h5Zone = 'nav';
+                self._h5Idx  = parseInt(navBtn.dataset.level);
                 e.dataTransfer.effectAllowed = 'move';
-                e.dataTransfer.setData('text/plain', String(dragSrcLevel));
-                // Delay class so the drag ghost captures the un-dimmed state
-                setTimeout(() => btn.classList.add('drillDowner_dragging'), 0);
-            });
+                e.dataTransfer.setData('text/plain', `nav:${navBtn.dataset.level}`);
+                setTimeout(() => navBtn.classList.add('drillDowner_dragging'), 0);
+            } else if(parkBtn) {
+                self._h5Zone = 'parking';
+                self._h5Dim  = parkBtn.dataset.dim;
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', `parking:${parkBtn.dataset.dim}`);
+                setTimeout(() => parkBtn.classList.add('drillDowner_dragging'), 0);
+            }
+        });
 
-            btn.addEventListener('dragend', () => {
-                btn.classList.remove('drillDowner_dragging');
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_drag_over'));
-                dragSrcLevel = null;
-            });
+        this.controls.addEventListener('dragend', () => {
+            self.controls.querySelectorAll('.drillDowner_dragging,.drillDowner_drag_over')
+                .forEach(el => el.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
+            self._h5Zone = null;
+        });
 
-            btn.addEventListener('dragover', (e) => {
+        this.controls.addEventListener('dragover', (e) => {
+            if(!self._h5Zone) return;
+            if(e.target.closest('.drillDowner_breadcrumb_item[data-level]') ||
+               e.target.closest('.drillDowner_breadcrumb_nav') ||
+               e.target.closest('.drillDowner_parking_area')) {
                 e.preventDefault();
                 e.dataTransfer.dropEffect = 'move';
-            });
+            }
+        });
 
-            btn.addEventListener('dragenter', (e) => {
-                e.preventDefault();
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_drag_over'));
-                if(parseInt(btn.dataset.level) !== dragSrcLevel)
-                    btn.classList.add('drillDowner_drag_over');
-            });
+        this.controls.addEventListener('dragenter', (e) => {
+            if(!self._h5Zone) return;
+            self.controls.querySelectorAll('.drillDowner_drag_over')
+                .forEach(el => el.classList.remove('drillDowner_drag_over'));
 
-            btn.addEventListener('dragleave', () => {
-                btn.classList.remove('drillDowner_drag_over');
-            });
+            const navBtn  = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
+            const parkArea = !e.target.closest('.drillDowner_parking_item') &&
+                              e.target.closest('.drillDowner_parking_area');
+            const navArea  = !navBtn && e.target.closest('.drillDowner_breadcrumb_nav');
 
-            btn.addEventListener('drop', (e) => {
-                e.preventDefault();
-                const fromIdx = parseInt(e.dataTransfer.getData('text/plain'));
-                const toIdx   = parseInt(btn.dataset.level);
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
-                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
-                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
-            });
+            if(navBtn) {
+                const isSelf = self._h5Zone === 'nav' && parseInt(navBtn.dataset.level) === self._h5Idx;
+                if(!isSelf) navBtn.classList.add('drillDowner_drag_over');
+            } else if(navArea && self._h5Zone === 'parking') {
+                navArea.classList.add('drillDowner_drag_over');
+            } else if(parkArea && self._h5Zone === 'nav') {
+                parkArea.classList.add('drillDowner_drag_over');
+            }
+        });
 
-            // ── Touch – iOS Safari & touch screens ────────────────────────
-            let ts = null; // touch state
+        this.controls.addEventListener('dragleave', (e) => {
+            const hi = e.target.closest('.drillDowner_drag_over');
+            if(hi && !hi.contains(e.relatedTarget)) hi.classList.remove('drillDowner_drag_over');
+        });
 
-            btn.addEventListener('touchstart', (e) => {
+        this.controls.addEventListener('drop', (e) => {
+            if(!self._h5Zone) return;
+            e.preventDefault();
+            self.controls.querySelectorAll('.drillDowner_dragging,.drillDowner_drag_over')
+                .forEach(el => el.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
+
+            const navBtn  = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
+            const parkArea = e.target.closest('.drillDowner_parking_area');
+            const navArea  = !navBtn && e.target.closest('.drillDowner_breadcrumb_nav');
+
+            if(self._h5Zone === 'nav') {
+                const fromIdx = self._h5Idx;
+                if(navBtn) {
+                    const toIdx = parseInt(navBtn.dataset.level);
+                    if(fromIdx !== toIdx)
+                        self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+                } else if(parkArea) {
+                    const newOrder = [...self.options.groupOrder];
+                    newOrder.splice(fromIdx, 1);
+                    self._applyNewGroupOrder(newOrder);
+                }
+            } else if(self._h5Zone === 'parking') {
+                const dim = self._h5Dim;
+                if(navBtn) {
+                    const toIdx = parseInt(navBtn.dataset.level);
+                    const newOrder = [...self.options.groupOrder];
+                    newOrder.splice(toIdx, 0, dim);
+                    self._applyNewGroupOrder(newOrder);
+                } else if(navArea) {
+                    self._applyNewGroupOrder([...self.options.groupOrder, dim]);
+                }
+            }
+            self._h5Zone = null;
+        });
+    }
+
+    // ── Touch drag – per-element, handles cross-zone (nav ↔ parking) ────────
+    _setupTouchOnDraggables(container) {
+        const self = this;
+        container.querySelectorAll('[draggable="true"]').forEach(el => {
+            let ts = null;
+
+            el.addEventListener('touchstart', (e) => {
                 if(e.touches.length !== 1) return;
                 const t = e.touches[0];
-                ts = { startX: t.clientX, startY: t.clientY, dragging: false, target: null };
+                ts = { startX: t.clientX, startY: t.clientY, dragging: false,
+                       targetType: null, target: null };
             }, { passive: true });
 
-            btn.addEventListener('touchmove', (e) => {
+            el.addEventListener('touchmove', (e) => {
                 if(!ts) return;
                 const t = e.touches[0];
-                const dx = Math.abs(t.clientX - ts.startX);
-                const dy = Math.abs(t.clientY - ts.startY);
+                const dx = Math.abs(t.clientX - ts.startX), dy = Math.abs(t.clientY - ts.startY);
                 if(!ts.dragging && (dx > 8 || dy > 8)) {
                     ts.dragging = true;
-                    btn.classList.add('drillDowner_dragging');
+                    el.classList.add('drillDowner_dragging');
                 }
                 if(!ts.dragging) return;
-                e.preventDefault(); // prevent scroll while dragging
+                e.preventDefault();
 
-                const el = document.elementFromPoint(t.clientX, t.clientY);
-                const tgt = el && el.closest('.drillDowner_breadcrumb_item[data-level]');
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_drag_over'));
-                if(tgt && tgt !== btn) {
-                    tgt.classList.add('drillDowner_drag_over');
-                    ts.target = tgt;
+                const pt       = document.elementFromPoint(t.clientX, t.clientY);
+                const navBtn   = pt && pt.closest('.drillDowner_breadcrumb_item[data-level]');
+                const parkArea = pt && !pt.closest('.drillDowner_parking_item') &&
+                                  pt.closest('.drillDowner_parking_area');
+                const navArea  = !navBtn && pt && pt.closest('.drillDowner_breadcrumb_nav');
+
+                if(self.controls) self.controls.querySelectorAll('.drillDowner_drag_over')
+                    .forEach(b => b.classList.remove('drillDowner_drag_over'));
+
+                if(navBtn && navBtn !== el) {
+                    navBtn.classList.add('drillDowner_drag_over');
+                    ts.targetType = 'navBtn'; ts.target = navBtn;
+                } else if(parkArea && !parkArea.contains(el)) {
+                    parkArea.classList.add('drillDowner_drag_over');
+                    ts.targetType = 'parkArea'; ts.target = parkArea;
+                } else if(navArea && !navArea.contains(el)) {
+                    navArea.classList.add('drillDowner_drag_over');
+                    ts.targetType = 'navArea'; ts.target = navArea;
                 } else {
-                    ts.target = null;
+                    ts.targetType = null; ts.target = null;
                 }
             }, { passive: false });
 
-            btn.addEventListener('touchend', (e) => {
+            el.addEventListener('touchend', (e) => {
                 if(!ts) return;
-                const { dragging, target } = ts;
-                btn.classList.remove('drillDowner_dragging');
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_drag_over'));
-                ts = null;
-                if(!dragging || !target) return;
-                e.preventDefault(); // suppress synthesised click after drag
-                const fromIdx = parseInt(btn.dataset.level);
-                const toIdx   = parseInt(target.dataset.level);
-                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
-                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+                const state = ts; ts = null;
+                el.classList.remove('drillDowner_dragging');
+                if(self.controls) self.controls.querySelectorAll('.drillDowner_drag_over')
+                    .forEach(b => b.classList.remove('drillDowner_drag_over'));
+                if(!state.dragging || !state.targetType) return;
+                e.preventDefault();
+
+                const isNavEl = !!el.closest('.drillDowner_breadcrumb_nav');
+                if(isNavEl) {
+                    const fromIdx = parseInt(el.dataset.level);
+                    if(state.targetType === 'navBtn') {
+                        const toIdx = parseInt(state.target.dataset.level);
+                        if(fromIdx !== toIdx)
+                            self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+                    } else if(state.targetType === 'parkArea') {
+                        const newOrder = [...self.options.groupOrder];
+                        newOrder.splice(fromIdx, 1);
+                        self._applyNewGroupOrder(newOrder);
+                    }
+                } else { // parking item
+                    const dim = el.dataset.dim;
+                    if(state.targetType === 'navBtn') {
+                        const toIdx = parseInt(state.target.dataset.level);
+                        const newOrder = [...self.options.groupOrder];
+                        newOrder.splice(toIdx, 0, dim);
+                        self._applyNewGroupOrder(newOrder);
+                    } else if(state.targetType === 'navArea') {
+                        self._applyNewGroupOrder([...self.options.groupOrder, dim]);
+                    }
+                }
             });
 
-            btn.addEventListener('touchcancel', () => {
-                if(!ts) return;
-                btn.classList.remove('drillDowner_dragging');
-                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
-                    b.classList.remove('drillDowner_drag_over'));
-                ts = null;
+            el.addEventListener('touchcancel', () => {
+                if(!ts) return; ts = null;
+                el.classList.remove('drillDowner_dragging');
+                if(self.controls) self.controls.querySelectorAll('.drillDowner_drag_over')
+                    .forEach(b => b.classList.remove('drillDowner_drag_over'));
             });
         });
     }
@@ -517,9 +613,10 @@ class DrillDowner {
         if(typeof this.options.onGroupOrderChange === 'function')
             this.options.onGroupOrderChange(newOrder, oldOrder, this);
 
-        // Re-render breadcrumbs then table
+        // Re-render breadcrumbs, parking area, then table
         const nav = this.controls && this.controls.querySelector('.drillDowner_breadcrumb_nav');
         if(nav) this._renderBreadcrumbs(nav);
+        this._renderParkingArea();
         this.render();
     }
 
@@ -530,6 +627,29 @@ class DrillDowner {
             arrow.classList.toggle('drillDowner_expanded', isExpanded);
             arrow.classList.toggle('drillDowner_collapsed', !isExpanded);
         });
+    }
+
+    _getParkedDimensions() {
+        if(!this.options.availableDimensions) return [];
+        return this.options.availableDimensions.filter(d => !this.options.groupOrder.includes(d));
+    }
+
+    _renderParkingArea() {
+        if(!this.options.availableDimensions || !this.controls) return;
+        const div = this.controls.querySelector('.drillDowner_parking_area');
+        if(!div) return;
+
+        const parked = this._getParkedDimensions();
+        if(parked.length === 0) {
+            div.innerHTML = '<span class="drillDowner_parking_empty">drag here to remove from grouping</span>';
+            return;
+        }
+
+        div.innerHTML = parked.map(key =>
+            `<button type="button" class="drillDowner_parking_item" data-dim="${key}" draggable="true"><span class="drillDowner_drag_handle" aria-hidden="true"></span><span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`
+        ).join('');
+
+        this._setupTouchOnDraggables(div);
     }
 
     // ---------- Table Rendering ----------

--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -269,9 +269,7 @@ class DrillDowner {
             this.controls.innerHTML = `
                 <div class="drillDowner_controls_container">
                     <div class="drillDowner_breadcrumb_nav"></div>
-                    <div class="drillDowner_grouping_controls">
-                        ${this.options.availableDimensions ? '<div class="drillDowner_parking_area"></div>' : ''}
-                    </div>
+                    <div class="drillDowner_grouping_controls"></div>
                 </div>`;
             container = this.controls.querySelector('.drillDowner_controls_container');
 
@@ -306,7 +304,7 @@ class DrillDowner {
             <label class="drillDowner_control_label">Group by:
             <select class="drillDowner_modern_select">${optionsHtml}</select>
             </label>
-        </div>`;
+        </div>${this.options.availableDimensions ? '<div class="drillDowner_parking_area"></div>' : ''}`;
 
         div.querySelector('select').addEventListener('change', (e) => {
             const val = e.target.value;

--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -331,11 +331,10 @@ class DrillDowner {
     _renderBreadcrumbs(nav) {
         nav.innerHTML = '';
         const items = [];
+        const isDraggable = this.options.groupOrder.length > 1;
         if(this.options.groupOrder.length > 0) {
             this.options.groupOrder.forEach((key, i) => {
-                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}">
-                    <span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span>
-                </button>`);
+                items.push(`<button type="button" class="drillDowner_breadcrumb_item" data-level="${i}"${isDraggable ? ' draggable="true"' : ''}>${isDraggable ? '<span class="drillDowner_drag_handle" aria-hidden="true"></span>' : ''}<span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`);
                 if(i < this.options.groupOrder.length - 1) {
                     items.push(`<button type="button" class="drillDowner_breadcrumb_arrow drillDowner_collapsed" data-arrow-level="${i}">
                         <span class="drillDowner_arrow_icon">▶</span>
@@ -359,6 +358,169 @@ class DrillDowner {
                 this.showToLevel(btn.classList.contains('drillDowner_expanded') ? lvl : lvl + 1);
             };
         });
+
+        if(isDraggable) this._setupBreadcrumbDrag(nav);
+    }
+
+    _setupBreadcrumbDrag(nav) {
+        const self = this;
+        let dragSrcLevel = null;
+
+        nav.querySelectorAll('.drillDowner_breadcrumb_item[data-level]').forEach(btn => {
+            // ── HTML5 Drag & Drop – desktop + Safari Mac ───────────────────
+            btn.addEventListener('dragstart', (e) => {
+                dragSrcLevel = parseInt(btn.dataset.level);
+                e.dataTransfer.effectAllowed = 'move';
+                e.dataTransfer.setData('text/plain', String(dragSrcLevel));
+                // Delay class so the drag ghost captures the un-dimmed state
+                setTimeout(() => btn.classList.add('drillDowner_dragging'), 0);
+            });
+
+            btn.addEventListener('dragend', () => {
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                dragSrcLevel = null;
+            });
+
+            btn.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+            });
+
+            btn.addEventListener('dragenter', (e) => {
+                e.preventDefault();
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                if(parseInt(btn.dataset.level) !== dragSrcLevel)
+                    btn.classList.add('drillDowner_drag_over');
+            });
+
+            btn.addEventListener('dragleave', () => {
+                btn.classList.remove('drillDowner_drag_over');
+            });
+
+            btn.addEventListener('drop', (e) => {
+                e.preventDefault();
+                const fromIdx = parseInt(e.dataTransfer.getData('text/plain'));
+                const toIdx   = parseInt(btn.dataset.level);
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
+                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
+                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+            });
+
+            // ── Touch – iOS Safari & touch screens ────────────────────────
+            let ts = null; // touch state
+
+            btn.addEventListener('touchstart', (e) => {
+                if(e.touches.length !== 1) return;
+                const t = e.touches[0];
+                ts = { startX: t.clientX, startY: t.clientY, dragging: false, target: null };
+            }, { passive: true });
+
+            btn.addEventListener('touchmove', (e) => {
+                if(!ts) return;
+                const t = e.touches[0];
+                const dx = Math.abs(t.clientX - ts.startX);
+                const dy = Math.abs(t.clientY - ts.startY);
+                if(!ts.dragging && (dx > 8 || dy > 8)) {
+                    ts.dragging = true;
+                    btn.classList.add('drillDowner_dragging');
+                }
+                if(!ts.dragging) return;
+                e.preventDefault(); // prevent scroll while dragging
+
+                const el = document.elementFromPoint(t.clientX, t.clientY);
+                const tgt = el && el.closest('.drillDowner_breadcrumb_item[data-level]');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                if(tgt && tgt !== btn) {
+                    tgt.classList.add('drillDowner_drag_over');
+                    ts.target = tgt;
+                } else {
+                    ts.target = null;
+                }
+            }, { passive: false });
+
+            btn.addEventListener('touchend', (e) => {
+                if(!ts) return;
+                const { dragging, target } = ts;
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                ts = null;
+                if(!dragging || !target) return;
+                e.preventDefault(); // suppress synthesised click after drag
+                const fromIdx = parseInt(btn.dataset.level);
+                const toIdx   = parseInt(target.dataset.level);
+                if(!isNaN(fromIdx) && !isNaN(toIdx) && fromIdx !== toIdx)
+                    self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
+            });
+
+            btn.addEventListener('touchcancel', () => {
+                if(!ts) return;
+                btn.classList.remove('drillDowner_dragging');
+                nav.querySelectorAll('.drillDowner_breadcrumb_item').forEach(b =>
+                    b.classList.remove('drillDowner_drag_over'));
+                ts = null;
+            });
+        });
+    }
+
+    _reorderArray(arr, fromIdx, toIdx) {
+        const result = [...arr];
+        const [item] = result.splice(fromIdx, 1);
+        result.splice(toIdx, 0, item);
+        return result;
+    }
+
+    _applyNewGroupOrder(newOrder) {
+        const oldOrder = [...this.options.groupOrder];
+        this.options.groupOrder = newOrder;
+        this.activeLedgerIndex = -1;
+        this.options.columns = [...this._defaultColumns];
+
+        // Sync the select box silently (no 'change' event – avoids double render)
+        const select = this.controls && this.controls.querySelector('select.drillDowner_modern_select');
+        if(select) {
+            const targetValue = newOrder.join(',');
+            let found = false;
+
+            if(this.options.groupOrderCombinations) {
+                for(let i = 0; i < this.options.groupOrderCombinations.length; i++) {
+                    if(this.options.groupOrderCombinations[i].join(',') === targetValue) {
+                        select.selectedIndex = i;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if(!found) {
+                for(let i = 0; i < select.options.length; i++) {
+                    if(select.options[i].value === targetValue) {
+                        select.selectedIndex = i;
+                        found = true;
+                        break;
+                    }
+                }
+            }
+
+            if(!found) {
+                const label = newOrder.map(col => this._getColHeader(col)).join(' → ');
+                select.add(new Option(label, targetValue));
+                select.value = targetValue;
+            }
+        }
+
+        if(typeof this.options.onGroupOrderChange === 'function')
+            this.options.onGroupOrderChange(newOrder, oldOrder, this);
+
+        // Re-render breadcrumbs then table
+        const nav = this.controls && this.controls.querySelector('.drillDowner_breadcrumb_nav');
+        if(nav) this._renderBreadcrumbs(nav);
+        this.render();
     }
 
     _updateBreadcrumbVisuals(level) {

--- a/src/drilldowner.css
+++ b/src/drilldowner.css
@@ -101,6 +101,23 @@
     gap: 4px;
     margin-bottom: 16px;
     flex-wrap: wrap;
+    min-height: 34px; /* always a drop target even when empty */
+    border-radius: 6px;
+    transition: background 0.15s, outline 0.15s;
+}
+
+.drillDowner_breadcrumb_nav.drillDowner_drag_over {
+    background: #eff6ff;
+    outline: 1px dashed #93c5fd;
+}
+
+.drillDowner_nav_empty_hint {
+    font-size: 12px;
+    color: #94a3b8;
+    font-style: italic;
+    padding: 4px 6px;
+    pointer-events: none;
+    user-select: none;
 }
 
 .drillDowner_breadcrumb_item {
@@ -285,6 +302,95 @@
     outline: none;
     border-color: #3b82f6;
     box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+}
+
+/* Parking area – unactive dimensions sit here, to the right of the select */
+.drillDowner_parking_area {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    padding: 3px 8px 3px 10px;
+    border-left: 2px solid #e2e8f0;
+    min-width: 70px;
+    min-height: 32px;
+    border-radius: 0 6px 6px 0;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.drillDowner_parking_area.drillDowner_drag_over {
+    background: #f0fdf4;
+    border-color: #86efac;
+}
+
+.drillDowner_parking_empty {
+    font-size: 11px;
+    color: #94a3b8;
+    font-style: italic;
+    user-select: none;
+    pointer-events: none;
+    white-space: nowrap;
+}
+
+.drillDowner_parking_item {
+    display: inline-flex;
+    align-items: center;
+    cursor: grab;
+    padding: 4px 9px;
+    border-radius: 6px;
+    border: 1px solid #e2e8f0;
+    background: #f1f5f9;
+    color: #64748b;
+    font-size: 12px;
+    font-weight: 500;
+    user-select: none;
+    white-space: nowrap;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.drillDowner_parking_item:hover {
+    background: #e8f0fe;
+    border-color: #c7d7fd;
+    color: #374151;
+}
+
+.drillDowner_parking_item .drillDowner_drag_handle {
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+
+.drillDowner_parking_item:hover .drillDowner_drag_handle {
+    opacity: 0.55;
+}
+
+.drillDowner_parking_item.drillDowner_dragging {
+    opacity: 0.45;
+    cursor: grabbing;
+}
+
+.drillDowner_parking_item.drillDowner_drag_over {
+    background: #dbeafe;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59,130,246,.25);
+}
+
+/* Touch / coarse pointer – larger tap targets */
+@media (pointer: coarse) {
+    .drillDowner_parking_item {
+        padding: 10px 14px;
+        font-size: 14px;
+        min-height: 44px;
+    }
+
+    .drillDowner_parking_item .drillDowner_drag_handle {
+        opacity: 0.5;
+    }
+
+    .drillDowner_parking_area {
+        gap: 6px;
+        padding: 5px 10px 5px 12px;
+        min-height: 44px;
+    }
 }
 
 /** controls & breadcrumbs **/

--- a/src/drilldowner.css
+++ b/src/drilldowner.css
@@ -104,23 +104,89 @@
 }
 
 .drillDowner_breadcrumb_item {
-    display: flex;
+    display: inline-flex;
     align-items: center;
     cursor: pointer;
-    padding: 8px 12px;
+    padding: 5px 10px;
     border-radius: 6px;
-    transition: all 0.2s ease;
+    border: 1px solid transparent;
+    transition: background 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
     font-weight: 500;
+    font-size: 13px;
     position: relative;
     user-select: none;
     background: #f8fafc;
     color: #374151;
+    white-space: nowrap;
+    line-height: 1.4;
 }
 
 .drillDowner_breadcrumb_item:hover {
-    background: #f1f5f9;
-    transform: translateY(-1px);
+    background: #e8f0fe;
+    border-color: #c7d7fd;
     color: #1f2937;
+}
+
+/* Drag handle – two columns of dots, only visible on hover (desktop) */
+.drillDowner_drag_handle {
+    display: inline-block;
+    width: 8px;
+    height: 14px;
+    margin-right: 5px;
+    flex-shrink: 0;
+    background-image:
+        radial-gradient(circle, #9ca3af 1.2px, transparent 1.2px),
+        radial-gradient(circle, #9ca3af 1.2px, transparent 1.2px);
+    background-size: 4px 4px, 4px 4px;
+    background-position: 0 0, 4px 2px;
+    background-repeat: repeat-y, repeat-y;
+    opacity: 0;
+    transition: opacity 0.15s;
+    vertical-align: middle;
+    cursor: grab;
+}
+
+.drillDowner_breadcrumb_item:hover .drillDowner_drag_handle {
+    opacity: 0.55;
+}
+
+/* Drag states */
+.drillDowner_breadcrumb_item[draggable="true"] {
+    cursor: grab;
+}
+
+.drillDowner_breadcrumb_item.drillDowner_dragging {
+    opacity: 0.45;
+    cursor: grabbing;
+}
+
+.drillDowner_breadcrumb_item.drillDowner_drag_over {
+    background: #dbeafe;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.25);
+}
+
+/* Touch / coarse pointer – larger tap targets */
+@media (pointer: coarse) {
+    .drillDowner_breadcrumb_item {
+        padding: 10px 14px;
+        font-size: 15px;
+        min-height: 44px;
+    }
+
+    .drillDowner_drag_handle {
+        width: 10px;
+        height: 18px;
+        margin-right: 7px;
+        opacity: 0.5; /* always visible on touch */
+    }
+
+    .drillDowner_breadcrumb_arrow {
+        min-width: 36px;
+        height: 36px;
+        font-size: 15px;
+        margin: 0 4px;
+    }
 }
 
 /* Interactive Arrow States */


### PR DESCRIPTION
## Summary by Sourcery

Add a draggable dimension parking area to manage active groupings in DrillDowner and enhance the breadcrumb UI for reordering.

New Features:
- Introduce an optional dimension parking area that holds non-active dimensions and allows dragging them into or out of the active group order.
- Support drag-and-drop and touch-based reordering of grouping breadcrumbs and moving dimensions between the breadcrumb row and the parking area.
- Add a new example page demonstrating the dimension parking area interaction with sample data.

Enhancements:
- Enhance breadcrumb controls with drag handles, visual drag states, and improved styles including touch-friendly sizing and spacing.
- Update breadcrumb navigation and parking area styling to provide clear drop targets, empty-state hints, and responsive behavior for coarse pointers.

Documentation:
- Document the dimension parking area behavior and configuration via a new HTML example showcasing availableDimensions and onGroupOrderChange usage.