### PR TITLE
Add parked dimension columns with reordering support

### DIFF
--- a/examples/Parking_Area_Example.html
+++ b/examples/Parking_Area_Example.html
@@ -12,7 +12,9 @@
 <p>
   Drag the active dimension buttons (top row) to <strong>reorder</strong> them.<br>
   Drag a button to the parking strip (right of the "Group by" select) to <strong>remove it from grouping</strong>.<br>
-  Drag a parked dimension back onto the active row to <strong>re-add it</strong>.
+  Drag a parked dimension back onto the active row to <strong>re-add it</strong>.<br>
+  <strong>Check the checkbox</strong> on any parked dimension to show it as an extra column in the table.<br>
+  <strong>Drag parked dimensions</strong> among themselves to set the column order.
 </p>
 
 <div id="controls"></div>

--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -41,6 +41,10 @@ class DrillDowner {
         this._defaultColumns = [...this.options.columns];
         this.options.colProperties = this.options.colProperties || {};
 
+        // Parked-dimensions feature state
+        this._parkedEnabled = new Set(); // keys of parked dims whose checkbox is checked (shown as columns)
+        this._parkedOrder   = this.options.availableDimensions ? [...this.options.availableDimensions] : [];
+
         this.azBar = this.options.azBarSelector ? (typeof this.options.azBarSelector === 'string' ?
             document.querySelector(this.options.azBarSelector) : this.options.azBarSelector) : null;
         this.controls = this.options.controlsSelector ? (typeof this.options.controlsSelector === 'string' ?
@@ -416,9 +420,9 @@ class DrillDowner {
             self.controls.querySelectorAll('.drillDowner_drag_over')
                 .forEach(el => el.classList.remove('drillDowner_drag_over'));
 
-            const navBtn  = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
-            const parkArea = !e.target.closest('.drillDowner_parking_item') &&
-                              e.target.closest('.drillDowner_parking_area');
+            const navBtn   = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
+            const parkItem = !navBtn && e.target.closest('.drillDowner_parking_item[data-dim]');
+            const parkArea = !navBtn && !parkItem && e.target.closest('.drillDowner_parking_area');
             const navArea  = !navBtn && e.target.closest('.drillDowner_breadcrumb_nav');
 
             if(navBtn) {
@@ -428,6 +432,8 @@ class DrillDowner {
                 navArea.classList.add('drillDowner_drag_over');
             } else if(parkArea && self._h5Zone === 'nav') {
                 parkArea.classList.add('drillDowner_drag_over');
+            } else if(parkItem && self._h5Zone === 'parking' && parkItem.dataset.dim !== self._h5Dim) {
+                parkItem.classList.add('drillDowner_drag_over');
             }
         });
 
@@ -442,8 +448,9 @@ class DrillDowner {
             self.controls.querySelectorAll('.drillDowner_dragging,.drillDowner_drag_over')
                 .forEach(el => el.classList.remove('drillDowner_dragging', 'drillDowner_drag_over'));
 
-            const navBtn  = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
-            const parkArea = e.target.closest('.drillDowner_parking_area');
+            const navBtn   = e.target.closest('.drillDowner_breadcrumb_item[data-level]');
+            const parkItem = !navBtn && e.target.closest('.drillDowner_parking_item[data-dim]');
+            const parkArea = !navBtn && !parkItem && e.target.closest('.drillDowner_parking_area');
             const navArea  = !navBtn && e.target.closest('.drillDowner_breadcrumb_nav');
 
             if(self._h5Zone === 'nav') {
@@ -452,7 +459,8 @@ class DrillDowner {
                     const toIdx = parseInt(navBtn.dataset.level);
                     if(fromIdx !== toIdx)
                         self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
-                } else if(parkArea) {
+                } else if(parkArea || parkItem) {
+                    // Drop on parking background or a parked item: remove from active grouping
                     const newOrder = [...self.options.groupOrder];
                     newOrder.splice(fromIdx, 1);
                     self._applyNewGroupOrder(newOrder);
@@ -466,6 +474,16 @@ class DrillDowner {
                     self._applyNewGroupOrder(newOrder);
                 } else if(navArea) {
                     self._applyNewGroupOrder([...self.options.groupOrder, dim]);
+                } else if(parkItem && parkItem.dataset.dim !== dim) {
+                    // Reorder parked items
+                    const toDim   = parkItem.dataset.dim;
+                    const fromIdx = self._parkedOrder.indexOf(dim);
+                    const toIdx   = self._parkedOrder.indexOf(toDim);
+                    if(fromIdx !== -1 && toIdx !== -1) {
+                        self._parkedOrder = self._reorderArray(self._parkedOrder, fromIdx, toIdx);
+                        self._renderParkingArea();
+                        if(self._parkedEnabled.has(dim) || self._parkedEnabled.has(toDim)) self.render();
+                    }
                 }
             }
             self._h5Zone = null;
@@ -479,6 +497,7 @@ class DrillDowner {
             let ts = null;
 
             el.addEventListener('touchstart', (e) => {
+                if(e.target.closest('input[type=checkbox]')) return; // let checkbox handle its own touch
                 if(e.touches.length !== 1) return;
                 const t = e.touches[0];
                 ts = { startX: t.clientX, startY: t.clientY, dragging: false,
@@ -498,8 +517,8 @@ class DrillDowner {
 
                 const pt       = document.elementFromPoint(t.clientX, t.clientY);
                 const navBtn   = pt && pt.closest('.drillDowner_breadcrumb_item[data-level]');
-                const parkArea = pt && !pt.closest('.drillDowner_parking_item') &&
-                                  pt.closest('.drillDowner_parking_area');
+                const parkItem = pt && !navBtn && pt.closest('.drillDowner_parking_item[data-dim]');
+                const parkArea = pt && !navBtn && !parkItem && pt.closest('.drillDowner_parking_area');
                 const navArea  = !navBtn && pt && pt.closest('.drillDowner_breadcrumb_nav');
 
                 if(self.controls) self.controls.querySelectorAll('.drillDowner_drag_over')
@@ -508,6 +527,9 @@ class DrillDowner {
                 if(navBtn && navBtn !== el) {
                     navBtn.classList.add('drillDowner_drag_over');
                     ts.targetType = 'navBtn'; ts.target = navBtn;
+                } else if(parkItem && parkItem !== el) {
+                    parkItem.classList.add('drillDowner_drag_over');
+                    ts.targetType = 'parkItem'; ts.target = parkItem;
                 } else if(parkArea && !parkArea.contains(el)) {
                     parkArea.classList.add('drillDowner_drag_over');
                     ts.targetType = 'parkArea'; ts.target = parkArea;
@@ -535,7 +557,8 @@ class DrillDowner {
                         const toIdx = parseInt(state.target.dataset.level);
                         if(fromIdx !== toIdx)
                             self._applyNewGroupOrder(self._reorderArray(self.options.groupOrder, fromIdx, toIdx));
-                    } else if(state.targetType === 'parkArea') {
+                    } else if(state.targetType === 'parkArea' || state.targetType === 'parkItem') {
+                        // Remove from active grouping (drop on parking zone)
                         const newOrder = [...self.options.groupOrder];
                         newOrder.splice(fromIdx, 1);
                         self._applyNewGroupOrder(newOrder);
@@ -549,6 +572,16 @@ class DrillDowner {
                         self._applyNewGroupOrder(newOrder);
                     } else if(state.targetType === 'navArea') {
                         self._applyNewGroupOrder([...self.options.groupOrder, dim]);
+                    } else if(state.targetType === 'parkItem' && state.target.dataset.dim !== dim) {
+                        // Reorder parked items
+                        const toDim   = state.target.dataset.dim;
+                        const fromIdx = self._parkedOrder.indexOf(dim);
+                        const toIdx   = self._parkedOrder.indexOf(toDim);
+                        if(fromIdx !== -1 && toIdx !== -1) {
+                            self._parkedOrder = self._reorderArray(self._parkedOrder, fromIdx, toIdx);
+                            self._renderParkingArea();
+                            if(self._parkedEnabled.has(dim) || self._parkedEnabled.has(toDim)) self.render();
+                        }
                     }
                 }
             });
@@ -629,7 +662,8 @@ class DrillDowner {
 
     _getParkedDimensions() {
         if(!this.options.availableDimensions) return [];
-        return this.options.availableDimensions.filter(d => !this.options.groupOrder.includes(d));
+        // Use _parkedOrder (user-arranged) as the authoritative sequence; filter to only those not active
+        return this._parkedOrder.filter(d => !this.options.groupOrder.includes(d));
     }
 
     _renderParkingArea() {
@@ -643,9 +677,27 @@ class DrillDowner {
             return;
         }
 
-        div.innerHTML = parked.map(key =>
-            `<button type="button" class="drillDowner_parking_item" data-dim="${key}" draggable="true"><span class="drillDowner_drag_handle" aria-hidden="true"></span><span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span></button>`
-        ).join('');
+        div.innerHTML = parked.map(key => {
+            const checked = this._parkedEnabled.has(key) ? ' checked' : '';
+            return `<div class="drillDowner_parking_item" data-dim="${key}" draggable="true">` +
+                `<span class="drillDowner_drag_handle" aria-hidden="true"></span>` +
+                `<input type="checkbox" class="drillDowner_parking_checkbox" data-dim="${key}"${checked} tabindex="-1" aria-label="${this._getColHeader(key)} as column">` +
+                `<span>${this._getGroupIcon(key)} ${this._getColHeader(key)}</span>` +
+                `</div>`;
+        }).join('');
+
+        // Checkbox toggle: add/remove from enabled set and re-render table
+        div.querySelectorAll('.drillDowner_parking_checkbox').forEach(cb => {
+            cb.addEventListener('change', (e) => {
+                e.stopPropagation();
+                const dim = e.target.dataset.dim;
+                if(e.target.checked) this._parkedEnabled.add(dim);
+                else this._parkedEnabled.delete(dim);
+                this.render();
+            });
+            // Prevent accidental drag when user clicks the checkbox
+            cb.addEventListener('mousedown', e => e.stopPropagation());
+        });
 
         this._setupTouchOnDraggables(div);
     }
@@ -657,9 +709,11 @@ class DrillDowner {
         const groupCols = this.options.groupOrder.length > 0 ? ["Item"] : ["#"];
         const activeLed = (this.options.groupOrder.length === 0 && this.activeLedgerIndex >= 0)
             ? this.options.ledger[this.activeLedgerIndex] : null;
+        // Parked dimensions whose checkbox is checked appear as extra columns (in user-arranged order)
+        const parkedActiveCols = this._getParkedDimensions().filter(d => this._parkedEnabled.has(d));
         const orderedCols = activeLed?.cols
             ? [...activeLed.cols, ...this.options.totals.filter(c => !activeLed.cols.includes(c))]
-            : [...this.options.totals, ...this.options.columns];
+            : [...this.options.totals, ...this.options.columns, ...parkedActiveCols];
         const allHeaders = [...groupCols, ...orderedCols.map(c => this._getColHeader(c))];
 
         const table = document.createElement('table');
@@ -1178,7 +1232,29 @@ class DrillDowner {
                 const fmt = this._getColFormatter(col);
                 td.innerHTML = fmt ? fmt(val, item) : val;
             } catch(er) {
-                console.error(`DrillDowner._appendDataCells: Error rendering [${col}]`, err, item);
+                console.error(`DrillDowner._appendDataCells: Error rendering [${col}]`, er, item);
+                td.innerHTML = '<span style="color:red" title="Render Error">⚠️</span>';
+            }
+        });
+
+        // Render checked parked-dimension columns (in user-arranged order)
+        const parkedActiveCols = this._getParkedDimensions().filter(d => this._parkedEnabled.has(d));
+        parkedActiveCols.forEach(col => {
+            const td = tr.insertCell();
+            td.className = this._getColClass(col);
+            try {
+                const renderer = this.options.colProperties[col]?.renderer ?? null;
+                if(renderer) {
+                    td.innerHTML = renderer(item, level, col, this.options.groupOrder, this.options);
+                    return;
+                }
+                let val = "";
+                if(gData && this._getColTogglesUp(col)) val = Array.from(new Set(gData.map(r => r[col]))).join(', ');
+                else if(!gData || isLeaf) val = item[col] ?? "";
+                const fmt = this._getColFormatter(col);
+                td.innerHTML = fmt ? fmt(val, item) : val;
+            } catch(er) {
+                console.error(`DrillDowner._appendDataCells: Error rendering parked col [${col}]`, er, item);
                 td.innerHTML = '<span style="color:red" title="Render Error">⚠️</span>';
             }
         });

--- a/src/drilldowner.css
+++ b/src/drilldowner.css
@@ -346,6 +346,7 @@
     user-select: none;
     white-space: nowrap;
     transition: background 0.15s, border-color 0.15s, color 0.15s;
+    gap: 5px;
 }
 
 .drillDowner_parking_item:hover {
@@ -357,6 +358,7 @@
 .drillDowner_parking_item .drillDowner_drag_handle {
     opacity: 0;
     transition: opacity 0.15s;
+    margin-right: 0; /* gap handles spacing */
 }
 
 .drillDowner_parking_item:hover .drillDowner_drag_handle {
@@ -374,6 +376,23 @@
     box-shadow: 0 0 0 2px rgba(59,130,246,.25);
 }
 
+/* Checkbox inside parking items */
+.drillDowner_parking_checkbox {
+    width: 13px;
+    height: 13px;
+    margin: 0;
+    cursor: pointer;
+    accent-color: #3b82f6;
+    flex-shrink: 0;
+}
+
+/* Dim that has its checkbox checked gets a subtle highlight */
+.drillDowner_parking_item:has(.drillDowner_parking_checkbox:checked) {
+    background: #eff6ff;
+    border-color: #bfdbfe;
+    color: #1e40af;
+}
+
 /* Touch / coarse pointer – larger tap targets */
 @media (pointer: coarse) {
     .drillDowner_parking_item {
@@ -384,6 +403,11 @@
 
     .drillDowner_parking_item .drillDowner_drag_handle {
         opacity: 0.5;
+    }
+
+    .drillDowner_parking_checkbox {
+        width: 18px;
+        height: 18px;
     }
 
     .drillDowner_parking_area {


### PR DESCRIPTION
## Summary
This PR enhances the parking area feature by allowing users to display parked dimensions as additional table columns. Users can now check a checkbox on any parked dimension to include it in the table, and reorder parked dimensions via drag-and-drop to control column order.

## Key Changes

- **Parked dimension state management**: Added `_parkedEnabled` Set to track which parked dimensions have their checkboxes checked, and `_parkedOrder` array to maintain user-arranged order of parked dimensions (replacing reliance on `availableDimensions` order)

- **Parking area UI enhancement**: 
  - Converted parking items from buttons to divs containing a checkbox, drag handle, and label
  - Added checkbox toggle functionality to show/hide parked dimensions as columns
  - Prevented accidental drag when clicking checkboxes via event handling

- **Drag-and-drop improvements**:
  - Extended drag-and-drop logic to support reordering parked dimensions among themselves
  - Added `parkItem` target detection in both mouse and touch handlers
  - Reordering parked items updates `_parkedOrder` and re-renders the parking area and table if needed

- **Table rendering**:
  - Modified `_getParkedDimensions()` to use `_parkedOrder` as the authoritative sequence
  - Updated column generation to include checked parked dimensions in the correct user-arranged order
  - Added rendering logic for parked dimension columns with support for custom renderers and formatters

- **CSS updates**:
  - Added flexbox gap spacing to parking items
  - Styled checkboxes with accent color and proper sizing
  - Added highlight styling for parking items with checked checkboxes
  - Increased touch target sizes for mobile accessibility

- **Bug fixes**: Fixed typo in error logging (`err` → `er`)

## Implementation Details

The feature maintains backward compatibility while adding new functionality. The `_parkedOrder` array is initialized from `availableDimensions` if provided, ensuring existing configurations work unchanged. Parked dimensions only appear as columns when both conditions are met: they're not in the active grouping AND their checkbox is checked.

https://claude.ai/code/session_012eUm2Yt6TsxFLothx6yrZG

## Summary by Sourcery

Enhance the dimension parking area so parked dimensions can be shown as additional, reorderable table columns while improving drag-and-drop behavior and styling.

New Features:
- Allow users to enable parked dimensions as extra table columns via checkboxes in the parking area.
- Support reordering of parked dimensions within the parking area to control the order of their corresponding columns.
- Render parked-dimension columns using existing custom renderers and formatters when enabled.

Bug Fixes:
- Correct error logging in data cell rendering to reference the proper error variable and show a visual indicator when rendering fails.

Enhancements:
- Use a dedicated parked-dimension order list as the authoritative sequence for parked dimensions instead of relying on availableDimensions order.
- Improve drag-and-drop handling with explicit parked-item detection for both mouse and touch interactions, preventing unintended drags from checkbox clicks.
- Update parking area UI to use div-based items with drag handles and checkboxes for better usability and accessibility.
- Refine parking area styling, including spacing, checkbox appearance, highlighting of enabled dimensions, and larger touch targets on coarse pointers.

Documentation:
- Expand the parking area example HTML to document enabling parked dimensions as columns and reordering them for column order.