### PR TITLE
Add Parking_Area_Example to index.html; add availableDimensions to al…

### DIFF
--- a/examples/Advanced_Example.html
+++ b/examples/Advanced_Example.html
@@ -27,6 +27,7 @@
 
   new DrillDowner('#advanced-table', tx, {
     groupOrder: ["account", "month", "category"],
+    availableDimensions: ["account", "month", "category"],
     groupOrderCombinations: [
       ["account", "month", "category"],
       ["category", "account", "month"]

--- a/examples/BalanceExample.html
+++ b/examples/BalanceExample.html
@@ -163,6 +163,7 @@
             // 2. Default View (Hierarchical)
             // Shows Net Income per Category (In - Out)
             groupOrder: ["category", "type"],
+            availableDimensions: ["category", "type", "date"],
             columns: ["desc", "date"],
 
             // 3. Ledger Views (Flat)

--- a/examples/BalanceExample_2.html
+++ b/examples/BalanceExample_2.html
@@ -40,6 +40,7 @@
     new DrillDowner('#table-container', data, {
       totals: ["in_val", "out_val", "balance"],
       groupOrder: ["cat", "type", "desc"],
+      availableDimensions: ["cat", "type", "desc"],
       columns: ["date", "desc"],
 
       // LEDGER MODE CONFIGURATION

--- a/examples/Books_example.html
+++ b/examples/Books_example.html
@@ -49,6 +49,7 @@
 
         // Start order (any one of your combinations)
         groupOrder: ["category", "publishingHouse", "subCategory", "title"],
+        availableDimensions: ["category", "publishingHouse", "subCategory", "title"],
 
         // Provide EXACT group orders you want available in the select:
         groupOrderCombinations: [

--- a/examples/DrillDowner_Example.html
+++ b/examples/DrillDowner_Example.html
@@ -120,6 +120,7 @@
         document.addEventListener('DOMContentLoaded', function() {
             const drillDowner = new DrillDowner('#table-container', sampleData, {
                 groupOrder: ["category", "brand","product","item",],
+                availableDimensions: ["category", "brand", "product", "item"],
                 columns: ["info"],
                 totals: ["price","quantity"],
                 colProperties: colProperties,

--- a/examples/LabelClickCallback.html
+++ b/examples/LabelClickCallback.html
@@ -62,6 +62,7 @@
         // Initialize DrillDowner with the onLabelClick pattern
         const drill = new DrillDowner('#table-container', stockData, {
             groupOrder: ["Warehouse", "Category", "Product"], // The hierarchy path
+            availableDimensions: ["Warehouse", "Category", "Product"],
             columns: ["Qty"],
             controlsSelector: '#controls',
 

--- a/examples/LedgerDrillExample.html
+++ b/examples/LedgerDrillExample.html
@@ -119,6 +119,7 @@
         const drillDowner = new DrillDowner('#table-container', sampleData, {
             // Standard Grouping Configuration
             groupOrder: ["category", "brand", "product"],
+            availableDimensions: ["category", "brand", "product"],
             groupOrderCombinations:[
                 ["category", "brand"],
                 ["brand", "product"]

--- a/examples/Medium_Example.html
+++ b/examples/Medium_Example.html
@@ -26,6 +26,7 @@
 
   new DrillDowner('#medium-table', orders, {
     groupOrder: ["region", "customer", "order"],
+    availableDimensions: ["region", "customer", "order"],
     groupOrderCombinations: [
       ["region", "customer", "order"],
       ["customer", "region", "order"]

--- a/examples/Simple_Example.html
+++ b/examples/Simple_Example.html
@@ -9,6 +9,7 @@
 </head>
 <body>
 <h2>Simple DrillDowner Example</h2>
+<div id="simple-controls"></div>
 <div id="simple-table"></div>
 
 <script>
@@ -21,6 +22,8 @@
 
   new DrillDowner('#simple-table', data, {
     groupOrder: ["department", "product"],
+    availableDimensions: ["department", "product"],
+    controlsSelector: '#simple-controls',
     totals: ["qty", "price"],
     colProperties: {
       department: { label: "Department", icon: "🗂️" },

--- a/examples/TogglesUp_Example.html
+++ b/examples/TogglesUp_Example.html
@@ -10,9 +10,11 @@
 </head>
 <body>
 <h1>No togglesUp</h1>
+<div id="dd_off_controls"></div>
 <div id="dd_off"></div>
 <hr>
 <h1>TogglesUp true</h1>
+<div id="dd_on_controls"></div>
 <div id="dd_on"></div>
 <h1>Sample code</h1>
 <pre style="white-space:pre;margin:1em;padding:0.3em;border:1px blue solid;">
@@ -72,6 +74,8 @@
     // 1) togglesUp OFF: group row cells for "status" are blank
     new DrillDowner("#dd_off", data, {
         groupOrder: ["category", "product"],
+        availableDimensions: ["category", "product"],
+        controlsSelector: '#dd_off_controls',
         columns: ["status"],
         totals: ["qty"],
         colProperties: {
@@ -86,6 +90,8 @@
     // 2) togglesUp ON: group row "status" shows combined unique statuses
     new DrillDowner("#dd_on", data, {
         groupOrder: ["category", "product"],
+        availableDimensions: ["category", "product"],
+        controlsSelector: '#dd_on_controls',
         columns: ["status"],
         totals: ["qty"],
         colProperties: {

--- a/examples/example.html
+++ b/examples/example.html
@@ -122,6 +122,7 @@
         new DrillDowner('#dd-container', salesData, {
             // Initial hierarchical grouping
             groupOrder: ["region", "country", "category", "product"],
+            availableDimensions: ["region", "country", "category", "product", "rep"],
 
             // Allow users to switch between these specific grouping views
             groupOrderCombinations: [

--- a/examples/tda.html
+++ b/examples/tda.html
@@ -26,7 +26,8 @@
             
             // 1. Default hierarchy
             groupOrder: ["clave", "Año - Mes", "Es", "Tipo"],
-            
+            availableDimensions: ["clave", "Año - Mes", "Es", "Tipo"],
+
             // 2. Dropdown grouping combinations
             groupOrderCombinations: [
                 ["clave", "Año - Mes", "Es", "Tipo"],

--- a/index.html
+++ b/index.html
@@ -93,6 +93,7 @@
         <li><a href="examples/BalanceExample_2.html" style="color: var(--primary); font-weight: 500;">Balance Example 2</a> &mdash; <span style="color:#64748b">Income/expense statement with running balances that accumulate across grouped and ledger views.</span></li>
         <li><a href="examples/LedgerDrillExample.html" style="color: var(--primary); font-weight: 500;">Ledger Drill Example</a> &mdash; <span style="color:#64748b">Transaction ledger sorted latest-first with category analysis and running balance.</span></li>
         <li><a href="examples/example.html" style="color: var(--primary); font-weight: 500;">Example</a> &mdash; <span style="color:#64748b">Sales dashboard with region-to-product hierarchies, formatted currency, and status badges.</span></li>
+        <li><a href="examples/Parking_Area_Example.html" style="color: var(--primary); font-weight: 500;">Parking Area Example</a> &mdash; <span style="color:#64748b">Drag dimensions in/out of grouping, check to show parked dims as extra columns, drag to reorder them.</span></li>
     </ul>
 </div>
 
@@ -139,6 +140,7 @@
         new DrillDowner('#dd-container', salesData, {
             // Initial hierarchical grouping
             groupOrder: ["region", "country", "category", "product"],
+            availableDimensions: ["region", "country", "category", "product", "rep"],
 
             // Allow users to switch between these specific grouping views
             groupOrderCombinations: [


### PR DESCRIPTION
…l examples

- index.html: add Parking_Area_Example link to the examples gallery
- index.html demo: add availableDimensions (region/country/category/product/rep)
- All 12 example files: add availableDimensions matching each file's groupable dimensions (derived from groupOrder + groupOrderCombinations); ledger examples keep their ledger config untouched
- Simple_Example.html + TogglesUp_Example.html: also add controlsSelector + matching div elements so the parking strip is fully functional

https://claude.ai/code/session_012eUm2Yt6TsxFLothx6yrZG

## Summary by Sourcery

Add availableDimensions configuration to all relevant DrillDowner examples and surface the new parking area example in the gallery.

New Features:
- Expose a Parking Area example in the main examples gallery and configure the index demo to support draggable and parkable dimensions via availableDimensions.

Enhancements:
- Define availableDimensions across example pages to align with each demo's groupable dimensions and showcase the new dimension-parking controls.
- Enable full parking-strip controls in the simple and togglesUp examples by wiring controls containers via controlsSelector.