### PR TITLE
Fix drill icon states and parking area visibility logic

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -139,8 +139,9 @@ class DrillDowner {
 
             const drillIcons = row.querySelectorAll('.drillDowner_drill_icon');
             drillIcons.forEach(icon => {
-                icon.classList.remove('drillDowner_drill_expanded');
-                icon.classList.add('drillDowner_drill_collapsed');
+                const isExpanded = lvl < level;
+                icon.classList.toggle('drillDowner_drill_expanded', isExpanded);
+                icon.classList.toggle('drillDowner_drill_collapsed', !isExpanded);
             });
         });
 
@@ -670,6 +671,11 @@ class DrillDowner {
         if(!this.options.availableDimensions || !this.controls) return;
         const div = this.controls.querySelector('.drillDowner_parking_area');
         if(!div) return;
+
+        if(this.activeLedgerIndex >= 0) {
+            div.innerHTML = '';
+            return;
+        }
 
         const parked = this._getParkedDimensions();
         if(parked.length === 0) {


### PR DESCRIPTION
## Summary
This PR fixes two issues in the DrillDowner component: incorrect drill icon state management during level changes and improper parking area visibility when a ledger is active.

## Key Changes
- **Drill icon state management**: Changed from always collapsing icons to conditionally toggling their state based on whether the current level is less than the target level. This ensures icons correctly reflect the expanded/collapsed state during drill operations.
- **Parking area visibility**: Added a check to clear the parking area when an active ledger is selected (`activeLedgerIndex >= 0`), preventing the parking area from displaying content when it shouldn't be visible.

## Implementation Details
- The drill icon toggle now uses `classList.toggle()` with a boolean condition to set the appropriate class based on the comparison `lvl < level`
- The parking area now returns early if a ledger is active, ensuring the empty state message and parked dimensions are not rendered in that scenario

https://claude.ai/code/session_01TVksSY1ELQrjtEBAMq4Umm

## Summary by Sourcery

Fix DrillDowner UI behavior for drill icons and parking area when changing levels and selecting active ledgers.

Bug Fixes:
- Ensure drill icons correctly reflect expanded or collapsed state based on the current drill level instead of always collapsing.
- Prevent the parking area from displaying content by clearing it when a ledger is actively selected.