### PR TITLE
Preserve expanded state when re-rendering drill-down table

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -238,7 +238,15 @@ class DrillDowner {
         this.container.innerHTML = '';
     }
 
-    render() {
+    render(keepState = false) {
+        let expandedHierarchies = new Set();
+        if(keepState && this.table) {
+            this.table.querySelectorAll('.drillDowner_drill_expanded').forEach(icon => {
+                const tr = icon.closest('tr');
+                if(tr) expandedHierarchies.add(tr.getAttribute('data-hierarchy'));
+            });
+        }
+
         this.grandTotals = this._calculateGrandTotals();
 
         if(this.options.groupOrder.length === 0 && this.activeLedgerIndex >= 0 && this.options.ledger[this.activeLedgerIndex]) {
@@ -261,6 +269,7 @@ class DrillDowner {
         this._renderTable();
         if(this.options.groupOrder.length > 0) {
             this.showToLevel(0);
+            if(keepState) this._restoreExpandState(expandedHierarchies);
         }
     }
 
@@ -1335,20 +1344,38 @@ class DrillDowner {
         icon.classList.toggle('drillDowner_drill_expanded', !expanded);
         icon.classList.toggle('drillDowner_drill_collapsed', expanded);
 
-        const setVisible = (pId, vis) => {
-            this.table.querySelectorAll(`tr[data-parent="${pId}"]`).forEach(r => {
-                r.style.display = vis ? '' : 'none';
-                if(!vis) {
-                    const i = r.querySelector('.drillDowner_drill_icon');
-                    if(i) {
-                        i.classList.remove('drillDowner_drill_expanded');
-                        i.classList.add('drillDowner_drill_collapsed');
-                    }
-                    setVisible(r.id, false);
+        this._setChildrenVisible(rowId, !expanded);
+    }
+
+    _setChildrenVisible(pId, vis) {
+        this.table.querySelectorAll(`tr[data-parent="${pId}"]`).forEach(r => {
+            r.style.display = vis ? '' : 'none';
+            if(!vis) {
+                const i = r.querySelector('.drillDowner_drill_icon');
+                if(i) {
+                    i.classList.remove('drillDowner_drill_expanded');
+                    i.classList.add('drillDowner_drill_collapsed');
                 }
-            });
-        };
-        setVisible(rowId, !expanded);
+                this._setChildrenVisible(r.id, false);
+            }
+        });
+    }
+
+    _restoreExpandState(expandedHierarchies) {
+        if(!expandedHierarchies.size) return;
+        // Sort by hierarchy depth so parents are expanded before children
+        const sorted = [...expandedHierarchies].sort(
+            (a, b) => JSON.parse(a).length - JSON.parse(b).length
+        );
+        sorted.forEach(h => {
+            const tr = this._findRowByHierarchy(JSON.parse(h));
+            if(!tr) return;
+            const icon = tr.querySelector('.drillDowner_drill_icon');
+            if(!icon || icon.classList.contains('drillDowner_drill_expanded')) return;
+            icon.classList.add('drillDowner_drill_expanded');
+            icon.classList.remove('drillDowner_drill_collapsed');
+            this._setChildrenVisible(tr.id, true);
+        });
     }
 
     _onAZClick() {

--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -268,8 +268,11 @@ class DrillDowner {
 
         this._renderTable();
         if(this.options.groupOrder.length > 0) {
-            this.showToLevel(0);
-            if(keepState) this._restoreExpandState(expandedHierarchies);
+            if(keepState) {
+                this._restoreExpandState(expandedHierarchies);
+            } else {
+                this.showToLevel(0);
+            }
         }
     }
 
@@ -1362,19 +1365,34 @@ class DrillDowner {
     }
 
     _restoreExpandState(expandedHierarchies) {
-        if(!expandedHierarchies.size) return;
-        // Sort by hierarchy depth so parents are expanded before children
-        const sorted = [...expandedHierarchies].sort(
-            (a, b) => JSON.parse(a).length - JSON.parse(b).length
-        );
-        sorted.forEach(h => {
-            const tr = this._findRowByHierarchy(JSON.parse(h));
+        // Single pass: compute final display state for every row without
+        // ever going through an intermediate "all collapsed" state, which
+        // would cause a visible flash on repaint.
+        this.table.querySelectorAll('tbody tr[data-level]').forEach(tr => {
+            const level = +tr.getAttribute('data-level');
+            if(level === 0) return; // level-0 rows are always visible
+
+            // A row is visible only when every ancestor is expanded.
+            // Its own hierarchy slice of length i is the hierarchy of its
+            // level-(i-1) ancestor, so we check each prefix.
+            const parsed = JSON.parse(tr.getAttribute('data-hierarchy') || '[]');
+            let visible = true;
+            for(let i = 1; i <= level; i++) {
+                if(!expandedHierarchies.has(JSON.stringify(parsed.slice(0, i)))) {
+                    visible = false;
+                    break;
+                }
+            }
+            tr.style.display = visible ? '' : 'none';
+        });
+
+        // Sync drill icon classes to match the expanded set
+        this.table.querySelectorAll('.drillDowner_drill_icon').forEach(icon => {
+            const tr = icon.closest('tr');
             if(!tr) return;
-            const icon = tr.querySelector('.drillDowner_drill_icon');
-            if(!icon || icon.classList.contains('drillDowner_drill_expanded')) return;
-            icon.classList.add('drillDowner_drill_expanded');
-            icon.classList.remove('drillDowner_drill_collapsed');
-            this._setChildrenVisible(tr.id, true);
+            const expanded = expandedHierarchies.has(tr.getAttribute('data-hierarchy'));
+            icon.classList.toggle('drillDowner_drill_expanded', expanded);
+            icon.classList.toggle('drillDowner_drill_collapsed', !expanded);
         });
     }
 


### PR DESCRIPTION
## Summary
This PR adds the ability to preserve the expanded/collapsed state of drill-down hierarchies when re-rendering the table, preventing the visual "flash" that occurs when all rows collapse and then re-expand to their previous state.

## Key Changes
- **Added `keepState` parameter to `render()` method**: When `true`, the method now captures which hierarchies are currently expanded before re-rendering, then restores that state afterward instead of collapsing everything to level 0.

- **Extracted `_setChildrenVisible()` helper method**: Refactored the nested `setVisible` function into a reusable instance method to avoid code duplication and improve maintainability.

- **Implemented `_restoreExpandState()` method**: A new method that efficiently restores the expanded state in a single pass without intermediate visual states:
  - Iterates through all table rows and determines visibility based on whether all ancestor hierarchies are in the expanded set
  - Syncs drill icon classes (expanded/collapsed) to match the restored state
  - Avoids the visual flash by computing final display states directly rather than going through intermediate collapsed states

## Implementation Details
- The expanded hierarchies are tracked using a `Set` of JSON-stringified hierarchy arrays for efficient lookup
- Visibility is determined by checking if every ancestor hierarchy (each prefix of the current row's hierarchy) is in the expanded set
- The restoration process handles the hierarchy hierarchy structure correctly by checking all prefixes up to the current level

https://claude.ai/code/session_012pYUCL3uoZpjdeA2cNvLaC

## Summary by Sourcery

Preserve the expanded/collapsed state of drill-down table rows across re-renders to avoid visual flashing when the table is refreshed.

New Features:
- Allow the drill-down table render routine to optionally keep the current expansion state of hierarchies when re-rendering.

Enhancements:
- Extract a reusable helper for toggling visibility of child rows in the drill-down hierarchy.
- Add a method to restore row visibility and drill icon states in a single pass based on previously expanded hierarchies.