### PR TITLE
Remove redundant sort operation in ledger calculation

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -751,8 +751,8 @@ class DrillDowner {
             const led = this.options.ledger[this.activeLedgerIndex];
             const calcKeys = (led.sort || []).map(k => k.startsWith('-') ? k.substring(1) : k);
 
-            const calcList = [...this.dataArr];
             this._sortData(this.dataArr, led.sort);
+            const calcList = [...this.dataArr];
 
             const runningTotals = {};
             let hasInitialBalance = false;
@@ -785,9 +785,6 @@ class DrillDowner {
                 });
                 balanceMap.set(item, itemOverrides);
             });
-
-            // --- PASS 2: Render in Display Order ---
-            this._sortData(this.dataArr, led.sort);
 
             // Determine if sort is Descending (starts with '-') to place Initial Balance at Bottom
             const isDescending = (led.sort && led.sort.length > 0 && led.sort[0].startsWith('-'));


### PR DESCRIPTION
## Summary
Eliminated a redundant data sort operation that was being performed twice during ledger calculations, improving performance by removing unnecessary work.

## Key Changes
- Moved `calcList` initialization to occur after the first `_sortData()` call instead of before, ensuring the calculation list uses the sorted data
- Removed the duplicate `_sortData()` call that was occurring in "PASS 2" after balance calculations were complete
- The sort order is now established once and reused for both calculations and rendering

## Implementation Details
The refactoring maintains the same logical flow while eliminating redundant sorting:
- Data is sorted once at the beginning of the calculation phase
- `calcList` is created from the already-sorted `dataArr`
- The duplicate sort operation that occurred after balance map processing has been removed
- The descending sort detection logic remains unchanged and continues to work correctly for determining Initial Balance placement

https://claude.ai/code/session_01EyGEiMQMLjmHkEzXrwo3EZ

## Summary by Sourcery

Optimize ledger drill-down calculations by removing a redundant data sort and basing calculations on the already-sorted dataset.

Enhancements:
- Create the calculation list from the ledger data after it has been sorted once, ensuring consistent ordering for calculations and rendering.
- Eliminate the second sort pass over ledger data to reduce duplicate work and improve performance during ledger calculations.