### PR TITLE
Add initial balance row rendering for grouped view

### DIFF
--- a/src/DrillDowner.js
+++ b/src/DrillDowner.js
@@ -782,7 +782,7 @@ class DrillDowner {
                 const props = this._getColProperty(col, 'balanceBehavior');
                 if(props) {
                     runningTotals[col] = (typeof props.initialBalance === 'number') ? props.initialBalance : 0;
-                    if(typeof props.initialBalance === 'number') hasInitialBalance = true;
+                    if(typeof props.initialBalance === 'number' && led.cols.includes(col)) hasInitialBalance = true;
                 } else {
                     runningTotals[col] = 0;
                 }
@@ -863,6 +863,46 @@ class DrillDowner {
 
             // --- GROUPED VIEW (HIERARCHICAL) ---
         } else {
+            // Render an Initial Balance row if any visible total column has one defined
+            const groupedHasInitialBalance = orderedCols.some(col => {
+                if(!this.options.totals.includes(col)) return false;
+                const props = this._getColProperty(col, 'balanceBehavior');
+                return props && typeof props.initialBalance === 'number';
+            });
+
+            if(groupedHasInitialBalance) {
+                const tr = tbody.insertRow();
+                tr.className = 'drillDowner_initial_row';
+                tr.style.backgroundColor = '#fafafa';
+                tr.style.fontStyle = 'italic';
+
+                let labelSet = false;
+                const indentCell = tr.insertCell();
+
+                orderedCols.forEach(col => {
+                    const td = tr.insertCell();
+                    const isTotal = this.options.totals.includes(col);
+                    if(isTotal) {
+                        td.className = 'drillDowner_num';
+                        const props = this._getColProperty(col, 'balanceBehavior');
+                        if(props && typeof props.initialBalance === 'number') {
+                            const dec = this._getColDecimals(col);
+                            const fmt = this._getColFormatter(col);
+                            td.innerHTML = fmt ? fmt(props.initialBalance, {}) : DrillDowner.formatNumber(props.initialBalance, dec);
+                        }
+                    } else {
+                        td.className = this._getColClass(col);
+                        if(!labelSet) {
+                            td.innerHTML = 'Initial Balance';
+                            labelSet = true;
+                        }
+                    }
+                });
+
+                // If all visible columns are totals, fall back to labelling the indent cell
+                if(!labelSet) indentCell.innerHTML = 'Initial Balance';
+            }
+
             this._sortData(this.dataArr, this.options.groupOrder);
             this._buildFlatRows(this.dataArr, this.options.groupOrder, 0, {}, [], tbody);
         }


### PR DESCRIPTION
## Summary
This PR adds support for displaying an "Initial Balance" row in the grouped (hierarchical) view of the DrillDowner table, bringing feature parity with the flat view. It also fixes a bug in the flat view's initial balance detection logic.

## Key Changes
- **Fixed flat view initial balance detection**: Modified the condition to only set `hasInitialBalance = true` when the column is included in the visible columns (`led.cols.includes(col)`), preventing unnecessary row creation for hidden columns
- **Added grouped view initial balance row**: Implemented rendering of an "Initial Balance" row in the grouped view that:
  - Checks if any visible total column has an initial balance defined
  - Creates a styled row with italic text and light gray background (`#fafafa`)
  - Displays the initial balance values formatted according to column specifications (decimals and custom formatters)
  - Labels the row appropriately, preferring the first non-total column or falling back to the indent cell if all visible columns are totals

## Implementation Details
- The grouped view initial balance row is inserted before the hierarchical data rows are built
- The row respects the column ordering and visibility settings
- Formatting is consistent with other numeric values in the table (using `_getColDecimals()`, `_getColFormatter()`, and `DrillDowner.formatNumber()`)
- The row styling uses the `drillDowner_initial_row` class for potential CSS customization

https://claude.ai/code/session_01BSwo1zNbCiuevP2qGNrfWq

## Summary by Sourcery

Add support for rendering an Initial Balance row in the grouped (hierarchical) DrillDowner view and correct initial balance detection in the flat view.

Bug Fixes:
- Ensure flat view only flags an initial balance when the corresponding column is visible, preventing creation of unnecessary initial balance rows for hidden columns.

Enhancements:
- Render an Initial Balance row in the grouped (hierarchical) view that respects visible total columns, column ordering, and existing numeric formatting, including a fallback label when all visible columns are totals.