### PR TITLE
Add calcSort/viewSort for separate balance and display ordering

### DIFF
--- a/.claude/commands/drilldowner.md
+++ b/.claude/commands/drilldowner.md
@@ -234,6 +234,13 @@ ledger: [
     label: "Newest First",
     cols: ["date", "description", "amount"],
     sort: ["-date"]                              // '-date' = descending by date
+  },
+  // calcSort/viewSort: accumulate balance oldest→newest, display newest→oldest
+  {
+    label: "Latest First (correct balance)",
+    cols: ["date", "description", "deposit", "withdrawal", "balance"],
+    calcSort: ["date"],    // order for running-balance accumulation (always ascending)
+    viewSort: ["-date"]    // order for display
   }
 ]
 ```
@@ -243,6 +250,18 @@ ledger: [
 A single object (not in an array) is also accepted and auto-wrapped.
 
 **Starting in ledger mode:** set `groupOrder: []` and define at least one `ledger` entry. The first ledger entry is shown on initial load.
+
+#### `calcSort` and `viewSort` — separate sort orders for balance vs. display
+
+Use these instead of `sort` when the running-balance accumulation order differs from the desired display order. The classic use case is a bank statement shown newest-first: you still need to accumulate the balance oldest-first.
+
+| Property | Purpose |
+|----------|---------|
+| `sort` | Single sort for both calculation and display |
+| `calcSort` | Sort for accumulation only. Omit to derive from `viewSort` (strips `-`). |
+| `viewSort` | Sort for display. Omit to use `calcSort` unchanged. |
+
+The `initialBalance` row (from `balanceBehavior.initialBalance`) is placed at the **top** when `viewSort` is ascending and at the **bottom** when `viewSort` is descending.
 
 ---
 
@@ -485,7 +504,7 @@ colProperties: {
 }
 ```
 
-### `DrillDowner.version` → `"1.2.2"`
+### `DrillDowner.version` → `"1.2.6"`
 
 ---
 
@@ -670,6 +689,12 @@ const dd = new DrillDowner('#table', transactions, {
       label: "Newest First",
       cols:  ["date", "description", "deposit", "withdrawal", "balance"],
       sort:  ["-date"]  // descending: newest first, initial balance at bottom
+    },
+    {
+      label: "Latest First (correct balance)",
+      cols:  ["date", "description", "deposit", "withdrawal", "balance"],
+      calcSort: ["date"],    // accumulate oldest→newest
+      viewSort: ["-date"]    // display newest→oldest
     }
   ],
   totals: ["deposit", "withdrawal", "balance"],

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DrillDowner
 
-**Version 1.2.2 · Zero dependencies · ES6 · Vanilla JS**
+**Version 1.2.6 · Zero dependencies · ES6 · Vanilla JS**
 
 DrillDowner turns a flat array of objects into an interactive drill-down table with collapsible hierarchy, subtotals, flexible grouping, and optional flat "ledger" views — all with no dependencies and no build step required.
 
@@ -120,8 +120,13 @@ colProperties: {
 const dd = new DrillDowner('#table', transactions, {
   groupOrder: [],
   ledger: [
+    // sort: ascending — oldest first, Initial Balance row at top
     { label: "Chronological", cols: ["date", "desc", "deposit", "withdrawal", "balance"], sort: ["date"] },
-    { label: "Newest First",  cols: ["date", "desc", "deposit", "withdrawal", "balance"], sort: ["-date"] }
+    // sort: descending — newest first, Initial Balance row at bottom
+    { label: "Newest First",  cols: ["date", "desc", "deposit", "withdrawal", "balance"], sort: ["-date"] },
+    // calcSort/viewSort: accumulate oldest-to-newest, display newest-to-oldest
+    { label: "Latest First (correct balance)", cols: ["date", "desc", "deposit", "withdrawal", "balance"],
+      calcSort: ["date"], viewSort: ["-date"] }
   ],
   totals: ["deposit", "withdrawal", "balance"],
   colProperties: {
@@ -225,7 +230,7 @@ const dd = new DrillDowner(container, dataArr, options)
 |--------|-------------|
 | `DrillDowner.formatNumber(n, decimals)` | `1234567.8, 2` → `"1,234,567.80"` |
 | `DrillDowner.formatDate(value, includeTime)` | `"2024-03-15"` → `"15/Mar/24"` |
-| `DrillDowner.version` | `"1.2.2"` |
+| `DrillDowner.version` | `"1.2.6"` |
 
 ### Public properties
 

--- a/docs/drilldowner_docs.md
+++ b/docs/drilldowner_docs.md
@@ -1,6 +1,6 @@
 # DrillDowner — API Reference
 
-**Version 1.2.2 · Zero dependencies · ES6 · Vanilla JS**
+**Version 1.2.6 · Zero dependencies · ES6 · Vanilla JS**
 
 ---
 
@@ -211,6 +211,46 @@ ledger: [
 - `cols` controls column order. Any `totals` not in `cols` are appended at the end.
 - Top-level `columns` is ignored in ledger mode.
 - Set `groupOrder: []` to start in ledger mode (first ledger entry shown on load).
+
+#### `calcSort` and `viewSort` — separate sort orders for balance vs. display
+
+When a ledger entry has a `balanceBehavior` column, DrillDowner needs two sort orders: one to accumulate the running balance chronologically and another to display rows in the user's preferred order. Use `calcSort` and `viewSort` instead of `sort` when these differ.
+
+```javascript
+ledger: [
+  {
+    label: "Latest First",
+    cols:  ["date", "description", "deposit", "withdrawal", "balance"],
+    calcSort: ["date"],       // Accumulate oldest→newest (always ascending)
+    viewSort: ["-date"]       // Display newest→oldest
+  }
+]
+```
+
+| Property | Purpose | Default |
+|----------|---------|---------|
+| `sort` | Single sort used for both calculation and display | — |
+| `calcSort` | Sort order for running-balance accumulation | Derived from `viewSort` (strip `-`) if omitted |
+| `viewSort` | Sort order for display | Same as `calcSort` if omitted |
+
+- If only `calcSort` is provided, `viewSort` defaults to the same order.
+- If only `viewSort` is provided, `calcSort` is derived by stripping `-` prefixes (ascending).
+- If neither is provided, `sort` is used for both. If `sort` is also absent, data renders in original array order.
+
+**Example — bank statement newest-first with correct balance:**
+
+```javascript
+ledger: [
+  {
+    label: "Newest First",
+    cols:  ["date", "description", "deposit", "withdrawal", "balance"],
+    calcSort: ["date", "id"],    // accumulate oldest→newest
+    viewSort: ["-date", "-id"]   // display newest→oldest
+  }
+]
+```
+
+The `initialBalance` row is placed at the **top** for ascending `viewSort` and at the **bottom** for descending `viewSort`.
 
 ---
 
@@ -460,7 +500,7 @@ colProperties: {
 }
 ```
 
-### `DrillDowner.version` → `"1.2.2"`
+### `DrillDowner.version` → `"1.2.6"`
 
 ---
 
@@ -636,8 +676,10 @@ const transactions = [
 const dd = new DrillDowner('#table', transactions, {
   groupOrder: [],
   ledger: [
-    { label: "Chronological", cols: ["date", "description", "deposit", "withdrawal", "balance"], sort: ["date"] },
-    { label: "Newest First",  cols: ["date", "description", "deposit", "withdrawal", "balance"], sort: ["-date"] }
+    { label: "Chronological",  cols: ["date", "description", "deposit", "withdrawal", "balance"], sort: ["date"] },
+    { label: "Newest First",   cols: ["date", "description", "deposit", "withdrawal", "balance"], sort: ["-date"] },
+    { label: "Latest (correct balance)", cols: ["date", "description", "deposit", "withdrawal", "balance"],
+      calcSort: ["date"], viewSort: ["-date"] }
   ],
   totals: ["deposit", "withdrawal", "balance"],
   colProperties: {

--- a/test/drilldowner_tests.html
+++ b/test/drilldowner_tests.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DrillDowner QUnit 1.2.2</title>
+    <title>DrillDowner QUnit 1.2.6</title>
 
     <!-- QUnit CSS and JS -->
     <link rel="stylesheet" href="../tools/qunit-2.24.1.css">
@@ -1719,6 +1719,177 @@
             assert.equal(firstRowNet, '1,080.00', "Running balance adds and subtracts correctly");
             assert.equal(secondRowNet, '1,030.00', "Running balance persists correctly to next row");
             assert.equal(dd.grandTotals.net, 1030, "Grand total matches the final running balance");
+
+            dd.destroy();
+        });
+
+        QUnit.test('calcSort + viewSort: balance accumulates ascending, displays descending', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            // Three transactions in chronological order
+            const data = [
+                { date: '2024-01-01', amount: 100 },  // balance after: 1100
+                { date: '2024-01-02', amount: 200 },  // balance after: 1300
+                { date: '2024-01-03', amount:  50 }   // balance after: 1350
+            ];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: [],
+                ledger: [{
+                    label: 'Latest First',
+                    cols: ['date', 'amount', 'balance'],
+                    calcSort: ['date'],      // accumulate oldest→newest
+                    viewSort: ['-date']      // display newest→oldest
+                }],
+                totals: ['amount', 'balance'],
+                colProperties: {
+                    balance: {
+                        balanceBehavior: { initialBalance: 1000, add: ['amount'], subtract: [] }
+                    }
+                }
+            });
+
+            const rows = Array.from(document.querySelectorAll(container + ' tbody tr:not(.drillDowner_initial_row)'));
+            assert.equal(rows.length, 3, 'Three data rows rendered');
+            // Display is newest-first: 2024-01-03 (1350), 2024-01-02 (1300), 2024-01-01 (1100)
+            const balances = rows.map(r => r.querySelector('td.drillDowner_num:last-child').textContent.trim());
+            assert.equal(balances[0], '1,350.00', 'Newest row shows highest balance (1350)');
+            assert.equal(balances[1], '1,300.00', 'Middle row shows 1300');
+            assert.equal(balances[2], '1,100.00', 'Oldest row shows 1100');
+
+            // Initial Balance row must be at the BOTTOM because viewSort is descending
+            const allRows = Array.from(document.querySelectorAll(container + ' tbody tr'));
+            const lastRow = allRows[allRows.length - 1];
+            assert.ok(lastRow.classList.contains('drillDowner_initial_row'), 'Initial Balance row is at the bottom for descending viewSort');
+
+            dd.destroy();
+        });
+
+        QUnit.test('calcSort only: viewSort defaults to same ascending order', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            const data = [
+                { seq: 3, val: 30 },
+                { seq: 1, val: 10 },
+                { seq: 2, val: 20 }
+            ];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: [],
+                ledger: [{
+                    label: 'Calc Only',
+                    cols: ['seq', 'val', 'bal'],
+                    calcSort: ['seq']   // viewSort should default to ['seq'] (ascending)
+                }],
+                totals: ['val', 'bal'],
+                colProperties: {
+                    bal: { balanceBehavior: { initialBalance: 0, add: ['val'], subtract: [] } }
+                }
+            });
+
+            const rows = Array.from(document.querySelectorAll(container + ' tbody tr:not(.drillDowner_initial_row)'));
+            const seqs = rows.map(r => r.querySelector('td:nth-child(2)').textContent.trim());
+            assert.deepEqual(seqs, ['1', '2', '3'], 'Rows displayed in ascending order when only calcSort is set');
+
+            dd.destroy();
+        });
+
+        QUnit.test('viewSort only: calcSort derived as ascending', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            const data = [
+                { seq: 1, val: 10 },
+                { seq: 3, val: 30 },
+                { seq: 2, val: 20 }
+            ];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: [],
+                ledger: [{
+                    label: 'View Only',
+                    cols: ['seq', 'val', 'bal'],
+                    viewSort: ['-seq']   // descending display; calcSort derived as ['seq']
+                }],
+                totals: ['val', 'bal'],
+                colProperties: {
+                    bal: { balanceBehavior: { initialBalance: 0, add: ['val'], subtract: [] } }
+                }
+            });
+
+            const rows = Array.from(document.querySelectorAll(container + ' tbody tr:not(.drillDowner_initial_row)'));
+            // Display should be descending: seq 3, 2, 1
+            const seqs = rows.map(r => r.querySelector('td:nth-child(2)').textContent.trim());
+            assert.deepEqual(seqs, ['3', '2', '1'], 'Rows displayed in descending order per viewSort');
+            // Balance accumulates ascending (seq 1→2→3: 10, 30, 60); display order shows 60, 30, 10
+            const bals = rows.map(r => r.querySelector('td.drillDowner_num:last-child').textContent.trim());
+            assert.equal(bals[0], '60.00', 'seq=3 row shows balance 60 (10+20+30)');
+            assert.equal(bals[2], '10.00', 'seq=1 row shows balance 10');
+
+            dd.destroy();
+        });
+
+        QUnit.test('Initial Balance row: ascending sort places it at top', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            const data = [{ d: 1, v: 5 }, { d: 2, v: 5 }];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: [],
+                ledger: [{ label: 'Asc', cols: ['d', 'v', 'bal'], sort: ['d'] }],
+                totals: ['v', 'bal'],
+                colProperties: { bal: { balanceBehavior: { initialBalance: 100, add: ['v'], subtract: [] } } }
+            });
+
+            const firstRow = document.querySelector(container + ' tbody tr:first-child');
+            assert.ok(firstRow.classList.contains('drillDowner_initial_row'), 'Initial Balance at top for ascending sort');
+
+            dd.destroy();
+        });
+
+        QUnit.test('Initial Balance row: descending sort places it at bottom', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            const data = [{ d: 1, v: 5 }, { d: 2, v: 5 }];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: [],
+                ledger: [{ label: 'Desc', cols: ['d', 'v', 'bal'], sort: ['-d'] }],
+                totals: ['v', 'bal'],
+                colProperties: { bal: { balanceBehavior: { initialBalance: 100, add: ['v'], subtract: [] } } }
+            });
+
+            const allRows = Array.from(document.querySelectorAll(container + ' tbody tr'));
+            const lastRow = allRows[allRows.length - 1];
+            assert.ok(lastRow.classList.contains('drillDowner_initial_row'), 'Initial Balance at bottom for descending sort');
+
+            dd.destroy();
+        });
+
+        QUnit.test('Grouped mode: Initial Balance row renders at top of tbody', function(assert) {
+            const container = '#test-container';
+            document.querySelector(container).innerHTML = '';
+            const data = [
+                { cat: 'A', deposit: 100, withdrawal: 0 },
+                { cat: 'B', deposit: 200, withdrawal: 50 }
+            ];
+
+            const dd = new DrillDowner(container, data, {
+                groupOrder: ['cat'],
+                totals: ['deposit', 'withdrawal', 'balance'],
+                colProperties: {
+                    balance: {
+                        balanceBehavior: { initialBalance: 500, add: ['deposit'], subtract: ['withdrawal'] }
+                    }
+                }
+            });
+
+            const firstRow = document.querySelector(container + ' tbody tr:first-child');
+            assert.ok(firstRow.classList.contains('drillDowner_initial_row'), 'First tbody row is Initial Balance in grouped mode');
+            assert.equal(firstRow.style.fontStyle, 'italic', 'Initial Balance row is styled italic');
+
+            const balCell = firstRow.querySelector('td.drillDowner_num');
+            assert.ok(balCell, 'Initial Balance row has a numeric cell');
+            assert.equal(balCell.textContent.trim(), '500.00', 'Initial Balance cell shows correct value');
 
             dd.destroy();
         });


### PR DESCRIPTION
## Summary
Introduces `calcSort` and `viewSort` properties for ledger entries, enabling running-balance accumulation in one sort order while displaying rows in a different order. This solves the classic bank statement use case: accumulate balances chronologically (oldest-first) but display newest-first.

## Key Changes
- **New ledger properties**: `calcSort` (for balance accumulation) and `viewSort` (for display)
  - `calcSort` defaults to ascending order derived from `viewSort` (strips `-` prefix)
  - `viewSort` defaults to same order as `calcSort` if omitted
  - Existing `sort` property continues to work for both when `calcSort`/`viewSort` not specified

- **Initial Balance row placement**: Now positioned at the **top** for ascending `viewSort` and at the **bottom** for descending `viewSort`, ensuring logical placement regardless of display order

- **Comprehensive test coverage**: Added 6 new QUnit tests covering:
  - Combined `calcSort` + `viewSort` with correct balance accumulation
  - `calcSort`-only behavior (viewSort defaults to same)
  - `viewSort`-only behavior (calcSort derived as ascending)
  - Initial Balance row placement in ascending sort
  - Initial Balance row placement in descending sort
  - Initial Balance row rendering in grouped mode

- **Documentation updates**: 
  - Updated API reference with `calcSort`/`viewSort` table and examples
  - Added bank statement example showing correct balance with newest-first display
  - Updated README and command reference with new feature explanation
  - Version bumped to 1.2.6

## Implementation Details
- Backward compatible: existing code using `sort` property is unaffected
- Automatic derivation of missing sort order prevents configuration errors
- Initial Balance row placement logic respects the final `viewSort` direction

https://claude.ai/code/session_01Vnfhy2nfwfjr2xVREFX45D

## Summary by Sourcery

Introduce separate sort options for ledger balance calculation and display ordering, and document their behavior including initial balance placement.

New Features:
- Add support for distinct `calcSort` and `viewSort` configuration in ledgers to decouple running-balance accumulation order from display order.

Enhancements:
- Clarify and exemplify ledger sorting behavior in docs, including correct newest-first bank statement configuration and initial balance row placement.
- Bump DrillDowner version metadata from 1.2.2 to 1.2.6 across documentation and test HTML.

Documentation:
- Extend API, README, and command reference documentation with `calcSort`/`viewSort` explanations and examples, including bank-statement usage and initial balance placement rules.

Tests:
- Add QUnit tests covering combined and individual `calcSort`/`viewSort` behaviors, initial balance row placement for ascending/descending sorts, and initial balance rendering in grouped mode.